### PR TITLE
Add no-load extension

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -330,6 +330,16 @@
         </tr>
         <tr>
             <td>
+                <a href="https://github.com/craigharman/htmx-ext-no-cache/README.md">
+                    no-load
+                </a>
+            </td>
+            <td>
+                This extension forces HTMX to bypass client caches and make a new request. An `hx-no-cache` header is also added to allow server-side caching to be bypassed.
+            </td>
+        </tr>
+        <tr>
+            <td>
                 <a href="https://github.com/craigharman/htmx-ext-no-load/README.md">
                     no-load
                 </a>

--- a/www/index.html
+++ b/www/index.html
@@ -330,6 +330,16 @@
         </tr>
         <tr>
             <td>
+                <a href="https://github.com/craigharman/htmx-ext-no-load/README.md">
+                    no-load
+                </a>
+            </td>
+            <td>
+                This extension stops HTMX from executing a request if the current browser path and the request path matches.
+            </td>
+        </tr>
+        <tr>
+            <td>
                 <a href="https://github.com/bigskysoftware/htmx-extensions/blob/main/src/path-deps/README.md">
                     path-deps
                 </a>


### PR DESCRIPTION
Add the no-load extension to extension list.
The no load extension blocks requests for requests that match the current browser url to avoid re-requests.