### PR TITLE
Fix typo on no-cache extension name

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -331,7 +331,7 @@
         <tr>
             <td>
                 <a href="https://github.com/craigharman/htmx-ext-no-cache/README.md">
-                    no-load
+                    no-cache
                 </a>
             </td>
             <td>


### PR DESCRIPTION
no-cache was incorrectly called "no-load" which is the extension below it.