### PR TITLE
Improve SSE reconnection logic

### DIFF
--- a/src/sse/sse.js
+++ b/src/sse/sse.js
@@ -203,15 +203,25 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
       // Otherwise, try to reconnect the EventSource
       if (source.readyState === EventSource.CLOSED) {
         retryCount = retryCount || 0
-        var timeout = Math.random() * (2 ^ retryCount) * 500
+        retryCount = Math.max(Math.min(retryCount * 2, 128), 1)
+        var timeout = retryCount * 500
         window.setTimeout(function() {
-          ensureEventSourceOnElement(elt, Math.min(7, retryCount + 1))
+          ensureEventSourceOnElement(elt, retryCount)
         }, timeout)
       }
     }
 
     source.onopen = function(evt) {
       api.triggerEvent(elt, 'htmx:sseOpen', { source })
+
+      if (retryCount && retryCount > 0) {
+        const childrenToFix = elt.querySelectorAll("[sse-swap], [data-sse-swap], [hx-trigger], [data-hx-trigger]")
+        for (let i = 0; i < childrenToFix.length; i++) {
+          registerSSE(childrenToFix[i])
+        }
+        // We want to increase the reconnection delay for consecutive failed attempts only
+        retryCount = 0
+      }
     }
 
     api.getInternalData(elt).sseEventSource = source


### PR DESCRIPTION
## Extension changes
- Rebind children SSE listeners on reconnection as a new event source was created. Current implementation makes the reconnection process a bit useless as all existing elements won't work anymore anyway, only new content swapped in would benefit from the reconnected event source
- Fix retry delay increment by power of 2 (current implementation is actually a XOR, not a pow operation)
- Reset delay on successful connection (only increase delay for consecutive failed connections)


Also added tests for the reconnection process + retry timeout increase & reset

## Testing mock changes:
- Made the actual "connection" happen 1ms after the connect call, to let the SSE extension bind its onopen and onerror callbacks in the meantime, as it would do in a real situation
-  Added a readyState property to mirror the EventSource.readyState property, with the same 3 enum values, instead of a simple "wasClosed" bool
- Connection failure simulation