### PR TITLE
Add trigger 'htmx:sseClose' to sse close event

### DIFF
--- a/src/sse/README.md
+++ b/src/sse/README.md
@@ -155,6 +155,28 @@ This event is dispatched just before the SSE event data is swapped into the DOM.
 
 This event is dispatched after the SSE event data has been swapped into the DOM. The `details` field is a [MessageEvent](https://developer.mozilla.org/en-US/docs/Web/API/EventSource/message_event) - this is the event created by [EventSource](https://developer.mozilla.org/en-US/docs/Web/API/EventSource) when it receives an SSE message.
 
+#### `htmx:sseClose`
+
+This event is dispatched in three different closing scenario. To control for the scenario the user can control for the evt.detail.sseclose property.
+
+```javascript
+document.body.addEventListener('htmx:sseClose', function (e) {
+    const reason = e.detail.type
+    switch(reason) {
+        case "nodeMissing":
+            // Parent node is missing and therefore connection was closed
+            ...
+        case "nodeRemoved":
+            // Parent node replacement caused closing of connection 
+            ...
+        case "message":
+            // connection was closed due to reception of message sse-close 
+            ...
+            
+    }
+})
+```
+
 ##### Details
 
 * `detail.elt` - The swap target.

--- a/src/sse/README.md
+++ b/src/sse/README.md
@@ -167,12 +167,11 @@ document.body.addEventListener('htmx:sseClose', function (e) {
             // Parent node is missing and therefore connection was closed
             ...
         case "nodeReplaced":
-            // Parent node replacement caused closing of connection 
+            // Parent node replacement caused closing of connection
             ...
         case "message":
-            // connection was closed due to reception of message sse-close 
+            // connection was closed due to reception of message sse-close
             ...
-            
     }
 })
 ```

--- a/src/sse/README.md
+++ b/src/sse/README.md
@@ -166,7 +166,7 @@ document.body.addEventListener('htmx:sseClose', function (e) {
         case "nodeMissing":
             // Parent node is missing and therefore connection was closed
             ...
-        case "nodeRemoved":
+        case "nodeReplaced":
             // Parent node replacement caused closing of connection 
             ...
         case "message":

--- a/src/sse/sse.js
+++ b/src/sse/sse.js
@@ -221,6 +221,7 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
     if (closeAttribute) {
       // close eventsource when this message is received
       source.addEventListener(closeAttribute, function() {
+        api.triggerEvent(elt, 'htmx:sseClose', { source })
         source.close()
       });
     }

--- a/src/sse/sse.js
+++ b/src/sse/sse.js
@@ -44,8 +44,10 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
         case 'htmx:beforeCleanupElement':
           var internalData = api.getInternalData(parent)
           // Try to remove remove an EventSource when elements are removed
-          if (internalData.sseEventSource) {
+          var source = internalData.sseEventSource
+          if (source) {
             api.triggerEvent(parent, 'htmx:sseClose', {
+              source,
               type: 'nodeReplaced',
             })
             internalData.sseEventSource.close()

--- a/src/sse/sse.js
+++ b/src/sse/sse.js
@@ -49,11 +49,11 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
           var internalData = api.getInternalData(parent);
           // Try to remove remove an EventSource when elements are removed
           if (internalData.sseEventSource) {
-            api.triggerEvent(elt, "htmx:sseClose", {
-              source,
-              type: "nodeRemoved",
+            api.triggerEvent(parent, "htmx:sseClose", {
+              type: "nodeReplaced",
             });
             internalData.sseEventSource.close();
+            
           }
 
           return;
@@ -229,6 +229,7 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
       // close eventsource when this message is received
       source.addEventListener(closeAttribute, function () {
         api.triggerEvent(elt, "htmx:sseClose", {
+          source,
           type: "message",
         });
         source.close();

--- a/src/sse/sse.js
+++ b/src/sse/sse.js
@@ -5,34 +5,30 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 
 */
 
-(function () {
+(function() {
   /** @type {import("../htmx").HtmxInternalApi} */
-  var api;
+  var api
 
-  htmx.defineExtension("sse", {
+  htmx.defineExtension('sse', {
+
     /**
      * Init saves the provided reference to the internal HTMX API.
      *
      * @param {import("../htmx").HtmxInternalApi} api
      * @returns void
      */
-    init: function (apiRef) {
+    init: function(apiRef) {
       // store a reference to the internal API.
-      api = apiRef;
+      api = apiRef
 
       // set a function in the public API for creating new EventSource objects
       if (htmx.createEventSource == undefined) {
-        htmx.createEventSource = createEventSource;
+        htmx.createEventSource = createEventSource
       }
     },
 
-    getSelectors: function () {
-      return [
-        "[sse-connect]",
-        "[data-sse-connect]",
-        "[sse-swap]",
-        "[data-sse-swap]",
-      ];
+    getSelectors: function() {
+      return ['[sse-connect]', '[data-sse-connect]', '[sse-swap]', '[data-sse-swap]']
     },
 
     /**
@@ -42,28 +38,27 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
      * @param {Event} evt
      * @returns void
      */
-    onEvent: function (name, evt) {
-      var parent = evt.target || evt.detail.elt;
+    onEvent: function(name, evt) {
+      var parent = evt.target || evt.detail.elt
       switch (name) {
-        case "htmx:beforeCleanupElement":
-          var internalData = api.getInternalData(parent);
+        case 'htmx:beforeCleanupElement':
+          var internalData = api.getInternalData(parent)
           // Try to remove remove an EventSource when elements are removed
           if (internalData.sseEventSource) {
-            api.triggerEvent(parent, "htmx:sseClose", {
-              type: "nodeReplaced",
-            });
-            internalData.sseEventSource.close();
-            
+            api.triggerEvent(parent, 'htmx:sseClose', {
+              type: 'nodeReplaced',
+            })
+            internalData.sseEventSource.close()
           }
 
-          return;
+          return
 
         // Try to create EventSources when elements are processed
-        case "htmx:afterProcessNode":
-          ensureEventSourceOnElement(parent);
+        case 'htmx:afterProcessNode':
+          ensureEventSourceOnElement(parent)
       }
-    },
-  });
+    }
+  })
 
   /// ////////////////////////////////////////////
   // HELPER FUNCTIONS
@@ -77,7 +72,7 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
    * @returns EventSource
    */
   function createEventSource(url) {
-    return new EventSource(url, { withCredentials: true });
+    return new EventSource(url, { withCredentials: true })
   }
 
   /**
@@ -89,84 +84,84 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
    */
   function registerSSE(elt) {
     // Add message handlers for every `sse-swap` attribute
-    if (api.getAttributeValue(elt, "sse-swap")) {
+    if (api.getAttributeValue(elt, 'sse-swap')) {
       // Find closest existing event source
-      var sourceElement = api.getClosestMatch(elt, hasEventSource);
+      var sourceElement = api.getClosestMatch(elt, hasEventSource)
       if (sourceElement == null) {
         // api.triggerErrorEvent(elt, "htmx:noSSESourceError")
-        return null; // no eventsource in parentage, orphaned element
+        return null // no eventsource in parentage, orphaned element
       }
 
       // Set internalData and source
-      var internalData = api.getInternalData(sourceElement);
-      var source = internalData.sseEventSource;
+      var internalData = api.getInternalData(sourceElement)
+      var source = internalData.sseEventSource
 
-      var sseSwapAttr = api.getAttributeValue(elt, "sse-swap");
-      var sseEventNames = sseSwapAttr.split(",");
+      var sseSwapAttr = api.getAttributeValue(elt, 'sse-swap')
+      var sseEventNames = sseSwapAttr.split(',')
 
       for (var i = 0; i < sseEventNames.length; i++) {
-        const sseEventName = sseEventNames[i].trim();
-        const listener = function (event) {
+        const sseEventName = sseEventNames[i].trim()
+        const listener = function(event) {
           // If the source is missing then close SSE
           if (maybeCloseSSESource(sourceElement)) {
-            return;
+            return
           }
 
           // If the body no longer contains the element, remove the listener
           if (!api.bodyContains(elt)) {
-            source.removeEventListener(sseEventName, listener);
-            return;
+            source.removeEventListener(sseEventName, listener)
+            return
           }
 
           // swap the response into the DOM and trigger a notification
-          if (!api.triggerEvent(elt, "htmx:sseBeforeMessage", event)) {
-            return;
+          if (!api.triggerEvent(elt, 'htmx:sseBeforeMessage', event)) {
+            return
           }
-          swap(elt, event.data);
-          api.triggerEvent(elt, "htmx:sseMessage", event);
-        };
+          swap(elt, event.data)
+          api.triggerEvent(elt, 'htmx:sseMessage', event)
+        }
 
         // Register the new listener
-        api.getInternalData(elt).sseEventListener = listener;
-        source.addEventListener(sseEventName, listener);
+        api.getInternalData(elt).sseEventListener = listener
+        source.addEventListener(sseEventName, listener)
       }
     }
 
     // Add message handlers for every `hx-trigger="sse:*"` attribute
-    if (api.getAttributeValue(elt, "hx-trigger")) {
+    if (api.getAttributeValue(elt, 'hx-trigger')) {
       // Find closest existing event source
-      var sourceElement = api.getClosestMatch(elt, hasEventSource);
+      var sourceElement = api.getClosestMatch(elt, hasEventSource)
       if (sourceElement == null) {
         // api.triggerErrorEvent(elt, "htmx:noSSESourceError")
-        return null; // no eventsource in parentage, orphaned element
+        return null // no eventsource in parentage, orphaned element
       }
 
       // Set internalData and source
-      var internalData = api.getInternalData(sourceElement);
-      var source = internalData.sseEventSource;
+      var internalData = api.getInternalData(sourceElement)
+      var source = internalData.sseEventSource
 
-      var triggerSpecs = api.getTriggerSpecs(elt);
-      triggerSpecs.forEach(function (ts) {
-        if (ts.trigger.slice(0, 4) !== "sse:") {
-          return;
+      var triggerSpecs = api.getTriggerSpecs(elt)
+      triggerSpecs.forEach(function(ts) {
+        if (ts.trigger.slice(0, 4) !== 'sse:') {
+          return
         }
 
         var listener = function (event) {
           if (maybeCloseSSESource(sourceElement)) {
-            return;
+            return
           }
           if (!api.bodyContains(elt)) {
-            source.removeEventListener(ts.trigger.slice(4), listener);
+            source.removeEventListener(ts.trigger.slice(4), listener)
           }
           // Trigger events to be handled by the rest of htmx
-          htmx.trigger(elt, ts.trigger, event);
-          htmx.trigger(elt, "htmx:sseMessage", event);
-        };
+          htmx.trigger(elt, ts.trigger, event)
+          htmx.trigger(elt, 'htmx:sseMessage', event)
+        }
 
         // Register the new listener
-        api.getInternalData(elt).sseEventListener = listener;
-        source.addEventListener(ts.trigger.slice(4), listener);
-      });
+        api.getInternalData(elt).sseEventListener = listener
+        source.addEventListener(ts.trigger.slice(4), listener)
+      })
     }
   }
 
@@ -180,32 +175,32 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
    */
   function ensureEventSourceOnElement(elt, retryCount) {
     if (elt == null) {
-      return null;
+      return null
     }
 
     // handle extension source creation attribute
-    if (api.getAttributeValue(elt, "sse-connect")) {
-      var sseURL = api.getAttributeValue(elt, "sse-connect");
+    if (api.getAttributeValue(elt, 'sse-connect')) {
+      var sseURL = api.getAttributeValue(elt, 'sse-connect')
       if (sseURL == null) {
-        return;
+        return
       }
 
-      ensureEventSource(elt, sseURL, retryCount);
+      ensureEventSource(elt, sseURL, retryCount)
     }
 
-    registerSSE(elt);
+    registerSSE(elt)
   }
 
   function ensureEventSource(elt, url, retryCount) {
-    var source = htmx.createEventSource(url);
+    var source = htmx.createEventSource(url)
 
-    source.onerror = function (err) {
+    source.onerror = function(err) {
       // Log an error event
-      api.triggerErrorEvent(elt, "htmx:sseError", { error: err, source });
+      api.triggerErrorEvent(elt, 'htmx:sseError', { error: err, source })
 
       // If parent no longer exists in the document, then clean up this EventSource
       if (maybeCloseSSESource(elt)) {
-        return;
+        return
       }
 
       // Otherwise, try to reconnect the EventSource
@@ -217,8 +212,7 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
           ensureEventSourceOnElement(elt, retryCount)
         }, timeout)
       }
-    };
-
+    }
 
     source.onopen = function(evt) {
       api.triggerEvent(elt, 'htmx:sseOpen', { source })
@@ -233,18 +227,18 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
       }
     }
 
+    api.getInternalData(elt).sseEventSource = source
 
-    api.getInternalData(elt).sseEventSource = source;
 
     var closeAttribute = api.getAttributeValue(elt, "sse-close");
     if (closeAttribute) {
       // close eventsource when this message is received
-      source.addEventListener(closeAttribute, function () {
-        api.triggerEvent(elt, "htmx:sseClose", {
+      source.addEventListener(closeAttribute, function() {
+        api.triggerEvent(elt, 'htmx:sseClose', {
           source,
-          type: "message",
-        });
-        source.close();
+          type: 'message',
+        })
+        source.close()
       });
     }
   }
@@ -258,35 +252,37 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
    */
   function maybeCloseSSESource(elt) {
     if (!api.bodyContains(elt)) {
-      var source = api.getInternalData(elt).sseEventSource;
+      var source = api.getInternalData(elt).sseEventSource
       if (source != undefined) {
-        api.triggerEvent(elt, "htmx:sseClose", {
+        api.triggerEvent(elt, 'htmx:sseClose', {
           source,
-          type: "nodeMissing",
-        });
-        source.close();
+          type: 'nodeMissing',
+        })
+        source.close()
         // source = null
-        return true;
+        return true
       }
     }
-    return false;
+    return false
   }
+
 
   /**
    * @param {HTMLElement} elt
    * @param {string} content
    */
   function swap(elt, content) {
-    api.withExtensions(elt, function (extension) {
-      content = extension.transformResponse(content, null, elt);
-    });
+    api.withExtensions(elt, function(extension) {
+      content = extension.transformResponse(content, null, elt)
+    })
 
-    var swapSpec = api.getSwapSpecification(elt);
-    var target = api.getTarget(elt);
-    api.swap(target, content, swapSpec);
+    var swapSpec = api.getSwapSpecification(elt)
+    var target = api.getTarget(elt)
+    api.swap(target, content, swapSpec)
   }
+
 
   function hasEventSource(node) {
-    return api.getInternalData(node).sseEventSource != null;
+    return api.getInternalData(node).sseEventSource != null
   }
-})();
+})()

--- a/src/sse/test/ext/sse.js
+++ b/src/sse/test/ext/sse.js
@@ -202,7 +202,7 @@ describe('sse extension', function() {
             '<div id="d1" hx-trigger="sse:e1" hx-get="/d1">div1</div>' +
             '</div>')
     htmx.on(div, "htmx:sseClose", (evt) => {
-      this.closeType = evt.detail.type 
+      this.closeType = evt.detail.type
     })
     this.clock.tick(1)
     div.click()
@@ -234,11 +234,11 @@ describe('sse extension', function() {
             '</div>')
     this.clock.tick(1)
     div.parentElement.removeChild(div)
-  
+
     htmx.on(div, "htmx:sseClose", (evt) => {
       this.closeType = evt.detail.type
     })
-    
+
     this.eventSource.sendEvent('e1')
     this.closeType.should.equal("nodeMissing")
     this.eventSource.readyState.should.equal(EventSource.CLOSED)


### PR DESCRIPTION
This PR adds a new trigger, `"htmx:sseClose"`, which is emitted when an SSE closing message is received.