### PR TITLE
Specify license for htmx-ext-head-support package.

### DIFF
--- a/src/head-support/package.json
+++ b/src/head-support/package.json
@@ -20,5 +20,6 @@
     "mocha-chrome": "https://github.com/Telroshan/mocha-chrome",
     "sinon": "^9.2.4",
     "htmx": "https://github.com/bigskysoftware/htmx#v2.0.0-beta4"
-  }
+  },
+  "license": "0BSD"
 }


### PR DESCRIPTION
I've selected the BSD Zero Clause License ([SPDX ID: 0BSD](https://spdx.org/licenses/0BSD.html)) because other extension packages in this repository appear to also use it.

See: https://docs.npmjs.com/cli/v10/configuring-npm/package-json#license.

Some background, I want to consume the htmx-ext-head-support package via https://www.webjars.org/ but their project requires a license to be specified first:

> Thanks for reporting. I think the easiest thing would be for them to add a license to: https://github.com/bigskysoftware/htmx-extensions/blob/main/src/head-support/package.json

_Originally posted by @jamesward in https://github.com/webjars/webjars/issues/2084#issuecomment-2211158183_