### PR TITLE
Remove reference to htmx 1.0

### DIFF
--- a/src/head-support/head-support.js
+++ b/src/head-support/head-support.js
@@ -1,7 +1,7 @@
 //==========================================================
 // head-support.js
 //
-// An extension to htmx 1.0 to add head tag merging.
+// An extension to add head tag merging.
 //==========================================================
 (function(){
 


### PR DESCRIPTION
Fix for issue #46.

Removes a reference to htmx 1.0 from a comment.
Doesn't add reference to htmx 2.0, since no other extension does.