### PR TITLE
docs: update extension example object

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,12 @@ Extensions can override the following default extension points to add or change 
 
 ```javascript
 {
-    onEvent : function(name, evt) {return true;},
-    transformResponse : function(text, xhr, elt) {return text;},
-    isInlineSwap : function(swapStyle) {return false;},
-    handleSwap : function(swapStyle, target, fragment, settleInfo) {return false;},
-    encodeParameters : function(xhr, parameters, elt) {return null;}
+  init: function(api) { return null },
+  getSelectors: function() { return null },
+  onEvent: function(name, evt) { return true },
+  transformResponse: function(text, xhr, elt) { return text },
+  isInlineSwap: function(swapStyle) { return false },
+  handleSwap: function(swapStyle, target, fragment, settleInfo) { return false },
+  encodeParameters: function(xhr, parameters, elt) { return null }
 }
 ```


### PR DESCRIPTION
Adding `getSelectors` to the object and changing the return type from `handleSwap` from `boolean` to `Node[]` which seems to be the correct one. 


See https://github.com/bigskysoftware/htmx/pull/2721 for a discussion about the underlying TypeScript type `HtmxExtension`. 