### PR TITLE
add safe-nonce

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -409,6 +409,16 @@
         </tr>
         <tr>
             <td>
+                <a href="https://github.com/MichaelWest22/htmx-extensions/blob/main/src/safe-nonce/README.md">
+                    safe-nonce
+                </a>
+            </td>
+            <td>
+                The `safe-nonce` extension can be used to improve the security of the application/web-site and help avoid XSS issues by allowing you to return known trusted inline scripts safely
+            </td>
+        </tr>
+        <tr>
+            <td>
                 <a href="https://github.com/Renerick/htmx-signalr/blob/master/README.md">
                     signalr
                 </a>


### PR DESCRIPTION
Adding my safe-nonce extension to the www site.

Note that the last two extensions were added at the bottom of the alphabetical list which is now confusing with json-enc not next to json-enc-custom etc.  Could we re-order these two out of order extensions as well?  I quickly tried this in my PR but it made my change un-readable