### PR TITLE
preload: added a "hx-preload" header to hx-get and href requests

### DIFF
--- a/src/preload/preload.js
+++ b/src/preload/preload.js
@@ -47,6 +47,7 @@ htmx.defineExtension('preload', {
         if (hxGet) {
           htmx.ajax('GET', hxGet, {
             source: node,
+            headers: { 'hx-preload': 'true' },
             handler: function(elt, info) {
               done(info.xhr.responseText)
             }
@@ -60,6 +61,8 @@ htmx.defineExtension('preload', {
         if (node.getAttribute('href')) {
           var r = new XMLHttpRequest()
           r.open('GET', node.getAttribute('href'))
+          r.setRequestHeader('hx-preload', 'true')
+          r.setRequestHeader('hx-request', 'true')
           r.onload = function() { done(r.responseText) }
           r.send()
         }


### PR DESCRIPTION
Also added hx-request header to href preload requests, in case implementations rely on hx-boost + hx-target to update a #main div, for instance.

If UI elements hook into `htmx:configRequest`, then a preload request may trigger some client-side action before the user actually commits to executing the request. A check for an hx-preload header can be used to avoid this.

Also, if an implementation uses the pattern of hx-boosted `<a href="">` tags and server-side logic to return only partials when a request contains the hx-request header, then the preload would unnecessarily load an entire page when a snippet would suffice. So, I've added an `hx-request` and `hx-preload` header to the XMLHTTPRequest as well.

Please let me know what you think about this change.