### PR TITLE
Remove duplicate safe-nonce description

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -439,7 +439,6 @@
         </tr>
         <tr>
             <td>
-                The `safe-nonce` extension can be used to improve the security of the application/web-site and help avoid XSS issues by allowing you to return known trusted inline scripts safely
                 <a href="https://github.com/benopotamus/htmx-ext-shoelace/blob/main/README.md">
                     Shoelace
                 </a>


### PR DESCRIPTION
The description of sale-nonce is duplicated on the shoealace row. it should be removed.