### PR TITLE
feat: now sse-swap tag accepts an inline swap strategy

### DIFF
--- a/src/sse/README.md
+++ b/src/sse/README.md
@@ -77,6 +77,14 @@ Multiple events in different elements (from the same source).
 </div>
 ```
 
+### Define inline swap strategy
+
+The default swap strategy used is `innerHTML`, you can change it using `hx-swap`. This can  cause some problems since `hx-swap` will be inherited. In these situations you can inline a swap strategy similar to the `hx-swap-oob` tag
+```html
+<div hx-ext="sse" sse-connect="/event_stream" sse-swap="beforeend:event1"></div>
+```
+the syntax is `[strategy:]event-name` or `[strategy:]message`
+
 ### Trigger Server Callbacks
 
 When a connection for server sent events has been established, child elements can listen for these events by using the special [`hx-trigger`](https://htmx.org/reference/hx-trigger.md) syntax `sse:<event_name>`.  This, when combined with an `hx-get` or similar will trigger the element to make a request.

--- a/src/sse/sse.js
+++ b/src/sse/sse.js
@@ -102,7 +102,19 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
       var sseEventNames = sseSwapAttr.split(',')
 
       for (var i = 0; i < sseEventNames.length; i++) {
-        const sseEventName = sseEventNames[i].trim()
+        let sseEventName
+        let sseSwapStyle
+        const sseEvent = sseEventNames[i].trim()
+        
+        if (sseEvent.indexOf(':') > 0) {
+          const e = sseEvent.split(':')
+          sseEventName = e[1]
+          sseSwapStyle = e[0]
+        } else {
+          sseEventName = sseEvent
+        }
+
+
         const listener = function(event) {
           // If the source is missing then close SSE
           if (maybeCloseSSESource(sourceElement)) {
@@ -119,7 +131,7 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
           if (!api.triggerEvent(elt, 'htmx:sseBeforeMessage', event)) {
             return
           }
-          swap(elt, event.data)
+          swap(elt, event.data, sseSwapStyle)
           api.triggerEvent(elt, 'htmx:sseMessage', event)
         }
 
@@ -273,12 +285,15 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
    * @param {HTMLElement} elt
    * @param {string} content
    */
-  function swap(elt, content) {
+  function swap(elt, content, swapStyle) {
     api.withExtensions(elt, function(extension) {
       content = extension.transformResponse(content, null, elt)
     })
 
     var swapSpec = api.getSwapSpecification(elt)
+    if (swapStyle) {
+      swapSpec.swapStyle = swapStyle
+    }
     var target = api.getTarget(elt)
     api.swap(target, content, swapSpec)
   }


### PR DESCRIPTION
Hi.
I've implemented this small feature that i use in my project and i believe could be useful.
I've decided to directly open the PR since i couldn't find contributor guidelines, hope its ok.

feature:
- added support for inline strategy like the hx-swap-oob tag