### PR TITLE
Do not emit htmx events when preloading requests

### DIFF
--- a/src/preload/preload.js
+++ b/src/preload/preload.js
@@ -49,8 +49,7 @@ htmx.defineExtension('preload', {
         if (hxGet) {
           // function that intercepts htmx.ajax requests and performs them
           // with XMLHttpRequest directly to avoid any side effects
-          node.prefetchEventHandler = function(event) {
-            node.removeEventListener('htmx:beforeRequest', node.prefetchEventHandler, true)
+          const prefetchEventHandler = function(event) {
             event.stopImmediatePropagation()
             event.preventDefault()
             // Since it is a GET request, we're only interested in the 
@@ -70,7 +69,11 @@ htmx.defineExtension('preload', {
           }
 
           // Add the event handler to the node
-          node.addEventListener('htmx:beforeRequest', node.prefetchEventHandler, true)
+          const options = { 
+            capture: true, 
+            once: true
+          }
+          node.addEventListener('htmx:beforeRequest', prefetchEventHandler, options)
 
           // let HTMX create the request to be intercepted by the event handler
           htmx.ajax('GET', hxGet, {

--- a/src/preload/preload.js
+++ b/src/preload/preload.js
@@ -31,10 +31,6 @@ htmx.defineExtension('preload', {
         if (attr(node, 'preload-images') == 'true') {
           document.createElement('div').innerHTML = html // create and populate a node to load linked resources, too.
         }
-
-        // once the request is done, remove the event handler
-        node.removeEventListener('htmx:beforeRequest', node.prefetchEventHandler, true)
-        delete node.prefetchEventHandler
       }
 
       return function() {
@@ -54,6 +50,7 @@ htmx.defineExtension('preload', {
           // function that intercepts htmx.ajax requests and performs them
           // with XMLHttpRequest directly to avoid any side effects
           node.prefetchEventHandler = function(event) {
+            node.removeEventListener('htmx:beforeRequest', node.prefetchEventHandler, true)
             event.stopImmediatePropagation()
             event.preventDefault()
             // Since it is a GET request, we're only interested in the 


### PR DESCRIPTION
As discussed on #90, here is a change to make prefetch hx-get request side-effect free.