### PR TITLE
Update deprecated `String.prototype.substr` uses in response-targets.js

### DIFF
--- a/src/response-targets/response-targets.js
+++ b/src/response-targets/response-targets.js
@@ -29,13 +29,13 @@
     var attrPossibilities = [
       respCode,
 
-      respCode.substr(0, 2) + '*',
-      respCode.substr(0, 2) + 'x',
+      respCode.substring(0, 2) + '*',
+      respCode.substring(0, 2) + 'x',
 
-      respCode.substr(0, 1) + '*',
-      respCode.substr(0, 1) + 'x',
-      respCode.substr(0, 1) + '**',
-      respCode.substr(0, 1) + 'xx',
+      respCode.substring(0, 1) + '*',
+      respCode.substring(0, 1) + 'x',
+      respCode.substring(0, 1) + '**',
+      respCode.substring(0, 1) + 'xx',
 
       '*',
       'x',


### PR DESCRIPTION
Hey there, I love this extension. I saw that this script was using the deprecated `substr` string method. In this particular case, it was super easy to swap out, since the "start index" of the calls are all zero. 

All tests passing.

Here is some info on the deprecation of `substr()` from the MDN Web Docs:

> Deprecated: This feature is no longer recommended. Though some browsers might still support it, it may have already been removed from the relevant web standards, may be in the process of being dropped, or may only be kept for compatibility purposes. Avoid using it, and update existing code if possible; see the [compatibility table](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr#browser_compatibility) at the bottom of this page to guide your decision. Be aware that this feature may cease to work at any time.

> Note: `substr()` is not part of the main ECMAScript specification — it's defined in Annex B: Additional ECMAScript Features for Web Browsers , which is normative optional for non-browser runtimes. Therefore, people are advised to use the standard `String.prototype.substring()`  and `String.prototype.slice()` methods instead to make their code maximally cross-platform friendly. The `String.prototype.substring()` page has some comparisons between the three methods.