### PR TITLE
Update readme to point to latest list of extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # htmx Extensions
 
 [htmx](https://htmx.org) provides an extension mechanism for defining and using extensions within htmx-based applications.
-A list of extensions can be found at <https://extensions.htmx.org>.  If you wish to contribute an extension to that
+A list of extensions can be found at <https://htmx.org/extensions>.  If you wish to contribute an extension to that
 list, open a PR request against <https://github.com/bigskysoftware/htmx-extensions/blob/dev/www/index.html>.
 
 ## Using Extensions


### PR DESCRIPTION
Since htmx v2.0.3, the list of extensions has moved back to the main site.
Update the extensions readme to match.