### PR TITLE
fix ws: `undefined is not an object (evaluating 'api.getInternalData(elt).webSocket.close')`

### DIFF
--- a/src/ws/test/ext/ws.js
+++ b/src/ws/test/ext/ws.js
@@ -618,6 +618,17 @@ describe('web-sockets extension', function() {
     this.messages[1].should.contains('"action":"B"')
   })
 
+  it('maybeClose does not raise when there is no socket', function() {
+    var div = make('<div hx-ext="ws" ws-connect="ws://localhost:8080"><div id="d1">div1</div></div>')
+    this.tickMock()
+    var internalData = div['htmx-internal-data']
+    should.exist(internalData.webSocket)
+    delete internalData.webSocket
+    should.not.exist(internalData.webSocket)
+    div.parentNode.removeChild(div)
+    this.tickMock()
+  })
+
   describe('Send immediately', function() {
     function checkCallForWsBeforeSend(spy, wrapper, message, target) {
       // Utility function to always check the same for htmx:wsBeforeSend caught by a spy

--- a/src/ws/ws.js
+++ b/src/ws/ws.js
@@ -411,8 +411,12 @@ This extension adds support for WebSockets to htmx.  See /www/extensions/ws.md f
    */
   function maybeCloseWebSocketSource(elt) {
     if (!api.bodyContains(elt)) {
-      api.getInternalData(elt).webSocket.close()
-      return true
+      var internalData = api.getInternalData(elt)
+      if (internalData.webSocket) {
+        internalData.webSocket.close()
+        return true
+      }
+      return false
     }
     return false
   }


### PR DESCRIPTION
This PR fixes #96 by checking whether `webSocket` is set. A similar check happens at L46 on the same file.