### PR TITLE
Broken Links in Extension Documentation

### DIFF
--- a/src/response-targets/README.md
+++ b/src/response-targets/README.md
@@ -135,4 +135,4 @@ may instead use the `x` character, e.g., `hx-target-4xx`._
 
 ## See also
 
-* [`hx-target`](https://htmx.org/reference/hx-target.md), specifies the target element to be swapped
+* [`hx-target`](https://htmx.org/attributes/hx-target/), specifies the target element to be swapped

--- a/src/sse/README.md
+++ b/src/sse/README.md
@@ -8,7 +8,7 @@ Use the following attributes to configure how SSE connections behave:
 
 * `sse-connect="<url>"` - The URL of the SSE server.
 * `sse-swap="<message-name>"` - The name of the message to swap into the DOM.
-* `hx-trigger="sse:<message-name>"` - SSE messages can also trigger HTTP callbacks using the [`hx-trigger`](https://htmx.org/reference/hx-trigger.md) attribute.
+* `hx-trigger="sse:<message-name>"` - SSE messages can also trigger HTTP callbacks using the [`hx-trigger`](https://htmx.org/attributes/hx-trigger/) attribute.
 * `sse-close=<message-name>` - To close the EventStream gracefully when that message is received. This might be helpful if you want to send information to a client that will eventually stop.
 
 ## Install
@@ -79,7 +79,7 @@ Multiple events in different elements (from the same source).
 
 ### Trigger Server Callbacks
 
-When a connection for server sent events has been established, child elements can listen for these events by using the special [`hx-trigger`](https://htmx.org/reference/hx-trigger.md) syntax `sse:<event_name>`.  This, when combined with an `hx-get` or similar will trigger the element to make a request.
+When a connection for server sent events has been established, child elements can listen for these events by using the special [`hx-trigger`](https://htmx.org/attributes/hx-trigger/) syntax `sse:<event_name>`.  This, when combined with an `hx-get` or similar will trigger the element to make a request.
 
 Here is an example:
 

--- a/src/ws/README.md
+++ b/src/ws/README.md
@@ -48,7 +48,7 @@ WebSockets extension support two configuration options:
 The example above establishes a WebSocket to the `/chatroom` end point. Content that is sent down from the websocket
 will
 be parsed as HTML and swapped in by the `id` property, using the same logic
-as [Out of Band Swaps](https://htmx.org/reference/hx-swap-oob.md).
+as [Out of Band Swaps](https://htmx.org/attributes/hx-swap-oob/).
 
 As such, if you want to change the swapping method (e.g., append content at the end of an element or delegate swapping
 to an extension),
@@ -178,7 +178,7 @@ If the event is cancelled, no further processing will occur and no messages will
 
 * `detail.parameters` - the parameters that will be submitted in the request
 * `detail.unfilteredParameters` - the parameters that were found before filtering
-  by [`hx-select`](https://htmx.org/reference/hx-select.md)
+  by [`hx-select`](https://htmx.org/attributes/hx-select)
 * `detail.headers` - the request headers. Will be attached to the body in `HEADERS` property, if not falsy
 * `detail.errors` - validation errors. Will prevent sending and
   trigger [`htmx:validation:halted`](https://htmx.org/events#htmx:validation:halted) event if not empty


### PR DESCRIPTION
Description: Fixed broken links for hx-trigger, hx-target and hx-swap-oob

Issue: #112 