### PR TITLE
Improve client-side-templates Extension to Handle Mustache Partials

### DIFF
--- a/src/client-side-templates/client-side-templates.js
+++ b/src/client-side-templates/client-side-templates.js
@@ -24,6 +24,24 @@ htmx.defineExtension('client-side-templates', {
       }
     }
 
+    var mustacheHalTemplate = htmx.closest(elt, '[mustache-hal-template]');
+		if (mustacheHalTemplate) {
+			var data = JSON.parse(text);
+			var templateId = mustacheTemplate.getAttribute('mustache-hal-template');
+			var template = htmx.find('#' + templateId);
+			if (template) {
+				var partials = {};
+				document.querySelectorAll('template[id]').forEach(tpl => {
+					partials[tpl.id] = tpl.innerHTML;
+				});
+				var renderedContent = Mustache.render(template.innerHTML, data, partials);
+				renderedContent = renderedContent.replace(/<!--/g, '').replace(/-->/g, ''); // No comments in the Mustache templates !
+				return renderedContent;
+			} else {
+				throw new Error('Unknown mustache template: ' + templateId);
+			}
+		}
+
     var handlebarsTemplate = htmx.closest(elt, '[handlebars-template]')
     if (handlebarsTemplate) {
       var data = JSON.parse(text)


### PR DESCRIPTION
## Description

This pull request enhances the client-side-templates extension for HTMX by addressing an issue with Mustache partials in strict HTML contexts, such as <tbody> elements in tables. Due to HTML parsing rules, Mustache expressions must often be wrapped in comment tags (<!-- -->) to ensure valid HTML. This update automatically removes those comment tags after rendering, simplifying the integration of Mustache partials.


Htmx version:
2.0.2

Changes
New Behavior:

Automatically strips HTML comment tags (<!-- and -->) from rendered content while preserving the Mustache-generated output.
Provides seamless support for Mustache partials within strict HTML elements like <tbody>.

## Testing

```
<template id="table-template">
    <table>
        <thead>
            <tr>
                <th>Column 1</th>
                <th>Column 2</th>
            </tr>
        </thead>
        <tbody>
            <!-- {{#items}} -->
                <!-- {{> row-template}} -->
            <!-- {{/items}} -->
        </tbody>
    </table>
</template>

<template id="row-template">
    <tr>
        <td>{{value1}}</td>
        <td>{{value2}}</td>
    </tr>
</template>

<div 
    id="table-container"
    hx-get="/api/data"
    hx-trigger="load"
    hx-target="#table-container"
    hx-swap="innerHTML"
    hx-ext="client-side-templates-hal"
    mustache-hal-template="table-template">
</div>
```
## Checklist

* [ ] I have read the [contribution guidelines](/CONTRIBUTING.md)
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
