### PR TITLE
Fix #119: Fix constructing more complex object with arrays

### DIFF
--- a/src/json-enc/json-enc.js
+++ b/src/json-enc/json-enc.js
@@ -14,27 +14,23 @@
     encodeParameters: function(xhr, parameters, elt) {
       xhr.overrideMimeType('text/json')
 
-      // group FormData parameters by key
-      const groupedParameters = Array.from(parameters.entries()).reduce((grouped, [key, value]) => {
-        if (Object.hasOwn(grouped, key)) {
-          if (!Array.isArray(grouped[key])) {
-            grouped[key] = [grouped[key]]
+      const object = {}
+      parameters.forEach(function(value, key) {
+        if (Object.hasOwn(object, key)) {
+          if (!Array.isArray(object[key])) {
+            object[key] = [object[key]]
           }
-          grouped[key].push(value)
+          object[key].push(value)
         } else {
-          grouped[key] = value
+          object[key] = value
         }
-        return grouped;
-      }, {});
+      })
 
       const vals = api.getExpressionVars(elt)
-      const object = Object.fromEntries(
-          Object.entries(groupedParameters).map(([key, value]) => {
-            // FormData encodes values as strings, restore hx-vals/hx-vars with their initial types
-            const typedValue = Object.hasOwn(vals, key) ? vals[key] : value
-            return [key, typedValue]
-          })
-      )
+      Object.keys(object).forEach(function(key) {
+        // FormData encodes values as strings, restore hx-vals/hx-vars with their initial types
+        object[key] = Object.hasOwn(vals, key) ? vals[key] : object[key]
+      })
 
       return (JSON.stringify(object))
     }

--- a/src/json-enc/test/ext/json-enc.js
+++ b/src/json-enc/test/ext/json-enc.js
@@ -143,7 +143,7 @@ describe('json-enc extension', function() {
       xhr.respond(200, {}, 'clicked')
     })
 
-    make(`<form hx-ext="json-enc" hx-post="/test" hx-vals="js:{'obj': {'x': 123}, 'number': 5000, 'numberString': '5000'}">
+    make(`<form hx-ext="json-enc" hx-post="/test" hx-vals="js:{'obj': {'x': 123}, 'number': 5000, 'numberString': '5000', 'array': ['text', 123, {'key': 'value'}]}">
              <button id="btn" type="submit">Submit</button>
           </form>`)
     var btn = byId('btn')
@@ -153,6 +153,7 @@ describe('json-enc extension', function() {
     values.number.should.equal(5000)
     values.numberString.should.equal('5000')
     chai.assert.deepEqual(values.obj, {'x': 123})
+    chai.assert.deepEqual(values.array, ['text', 123, {'key': 'value'}])
   })
 
   it('handles multiple values per key', function() {


### PR DESCRIPTION
Fixing the bug #119 

## Description
Fixed incorrect array handling when combining complex hx-vals with json-enc. Previously, when processing:
`<button hx-ext="json-enc" hx-vals='{"Id":1,"Items":["abc","xyz"]}'> ...</button>`

The `encodeParameters` function gets as input FormData object like:
- Id: '1'
- Items: "abc"
- Items: "xyz"

When retrieving types from hx-vals, for each entry with an `Items` key, whole array was added to the result object:
```
{
    Id: 1,
    Items: [ ["abc", "xyz"], ["abc", "xyz"] ]
}
```

Instead of:
```
{
    Id: 1,
    Items: ["abc", "xyz"]
}
```

To change this behaviour, the function now first groups FormData parameters by keys, and then maps raw values to types from hx-vals.

## Testing

In the test `handles hx-vals properly` added an array-type value (`'array': ['text', 123, {'key': 'value'}]`) and expects it to to be properly included in the body.

## Checklist

* [x] I have read the [contribution guidelines](/CONTRIBUTING.md)
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
