### PR TITLE
Add `reconnect()` to socketWrapper public interface

### DIFF
--- a/src/ws/test/ext/ws.js
+++ b/src/ws/test/ext/ws.js
@@ -629,7 +629,7 @@ describe('web-sockets extension', function() {
     this.tickMock()
   })
 
-  it('re-establishes then connection using reconnect()', function() {
+  it('re-establishes closed connections using reconnect()', function() {
     var handledEventTypes = []
     var handler = function(evt) { handledEventTypes.push(evt.detail.event.type) }
     var reconnect = function(evt) { setTimeout(() => evt.detail.socketWrapper.reconnect()) }

--- a/src/ws/test/ext/ws.js
+++ b/src/ws/test/ext/ws.js
@@ -629,6 +629,32 @@ describe('web-sockets extension', function() {
     this.tickMock()
   })
 
+  it('re-establishes then connection using reconnect()', function() {
+    var handledEventTypes = []
+    var handler = function(evt) { handledEventTypes.push(evt.detail.event.type) }
+    var reconnect = function(evt) { setTimeout(() => evt.detail.socketWrapper.reconnect()) }
+
+    htmx.on('htmx:wsConnecting', handler)
+
+    var div = make('<div hx-get="/test" hx-swap="outerHTML" hx-ext="ws" ws-connect="ws://localhost:8080">')
+
+    htmx.on(div, 'htmx:wsClose', handler)
+    htmx.on(div, 'htmx:wsClose', reconnect)
+
+    this.tickMock()
+    this.socketServer.close()
+
+    this.tickMock()
+    handledEventTypes.should.eql(['connecting', 'close', 'connecting'])
+
+    this.tickMock()
+    this.socketServer.close()
+
+    htmx.off('htmx:wsConnecting', handler)
+    htmx.off(div, 'htmx:wsClose', handler)
+    htmx.off(div, 'htmx:wsClose', reconnect)
+  })
+
   describe('Send immediately', function() {
     function checkCallForWsBeforeSend(spy, wrapper, message, target) {
       // Utility function to always check the same for htmx:wsBeforeSend caught by a spy

--- a/src/ws/ws.js
+++ b/src/ws/ws.js
@@ -289,6 +289,7 @@ This extension adds support for WebSockets to htmx.  See /www/extensions/ws.md f
     wrapper.publicInterface = {
       send: wrapper.send.bind(wrapper),
       sendImmediately: wrapper.sendImmediately.bind(wrapper),
+      reconnect: wrapper.init.bind(wrapper),
       queue: wrapper.messageQueue
     }
 


### PR DESCRIPTION
## Description
This pull request adds a `reconnect()` method to the socket wrapper. It can be used re-establish a closed connection.

Currently, this can be accomplished by using *htmx-internal-data* as follows:

```js
document.addEventListener('htmx:wsClose', e => {
  setTimeout(() => e.detail.elt['htmx-internal-data'].webSocket.init());
});
```

By adding reconnect() to the socketWrapper public interface, we can rewrite the above to the much nicer:

```js
document.addEventListener('htmx:wsClose', e => {
  setTimeout(() => e.detail.socketWrapper.reconnect());
});
```

*Note: In both cases, we might want to check the close reason and/or implement incremental backoff prior to blindly reconnecting, which might end us in an infinite loop*.

Htmx version: 2.0
Used extension(s) version(s): ws

Corresponding issue: #129

## Testing
I've tested this manually in a production setup, observing:

1. The htmx:wsClose event is triggered (event is CloseEvent {isTrusted: true, wasClean: true, code: 1001, reason: 'Going away', type: 'close'...})
2. The call to e.detail.elt['htmx-internal-data'].webSocket.init() reopens the socket
3. Sending data from inside a ws-send form uses the freshly opened socket

A test added to the `test` subdirectory verifies this behavior.

## Checklist

* [x] I have read the [contribution guidelines](/CONTRIBUTING.md)
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
