### PR TITLE
sse: Close connection before page switch

### DIFF
--- a/src/sse/sse.js
+++ b/src/sse/sse.js
@@ -25,6 +25,17 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
       if (htmx.createEventSource == undefined) {
         htmx.createEventSource = createEventSource
       }
+
+      // close SSE connections when page is about to unload
+      // cf. https://github.com/bigskysoftware/htmx/discussions/2109
+      window.addEventListener('beforeunload', function() {
+        document.querySelectorAll('[sse-connect], [hx-sse]').forEach(function(elt) {
+          var internalData = api.getInternalData(elt);
+          if (internalData && internalData.sseEventSource) {
+              internalData.sseEventSource.close();
+          }
+        });
+      });
     },
 
     getSelectors: function() {


### PR DESCRIPTION
## Description
This PR may require changes before needing merge. All it does is **unconditionally** close the SSE connections before the page is about to be switched. The problem is that - on Chrome (but not Safari) if we do not do this, then the SSE connections are kept alive and for every page/route switch, there will be O(n) active SSE connections, which sometimes to normal page requests handing (in `pending` mode) for sometime before the server responds (using Haskell servant here).

Htmx version: `https://unpkg.com/htmx.org@2.0.3`
Used extension(s) version(s): `sse` from master

Corresponding issue: https://github.com/bigskysoftware/htmx/discussions/2109

I'll leave this as draft just to indicate that a) it is not ready to be merged, and b) provide a fork for other interested party to rely upon.

## Testing


## Checklist

* [ ] I have read the [contribution guidelines](https://github.com/bigskysoftware/htmx-extensions/blob/main/CONTRIBUTING.md)
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
