### PR TITLE
Correct preload initialisation on forms with fieldsets

### DIFF
--- a/src/preload/preload.js
+++ b/src/preload/preload.js
@@ -90,7 +90,9 @@
       for (let i = 0; i < form.elements.length; i++) {
         const element = form.elements.item(i);
         init(element);
-        element.labels.forEach(init);
+        if ("labels" in element) {
+          element.labels.forEach(init);
+        }
       }
       return
     }

--- a/src/preload/test/ext/forms.js
+++ b/src/preload/test/ext/forms.js
@@ -244,5 +244,21 @@ describe('preload extension preloads forms', function() {
 
       should.equal(requests.length, 1)
     })
+
+    it('skips label initialisation for fieldsets (issue 149)', function() {
+      const form = make(`
+        <form action="/test" method="get" preload>
+	  <fieldset>
+            <input type="text" name="name" value="John">
+	  </fieldset>
+          <input type="submit" value="Submit">
+        </form>
+      `)
+      const submitButton = form.querySelector("input[type='submit']")
+
+      htmx.trigger(submitButton, 'mousedown')
+
+      should.equal(requests.length, 1)
+      should.equal(requests[0].url, '/test?name=John')
+    })
   })
-  


### PR DESCRIPTION
## Description
Fixes #149.

Versions:
htmx 2.0.4 and preload 2.1.1.

## Testing
Test added to test suite.

## Checklist

I verified test output directly in the browsers (Firefox and Chromium).