### PR TITLE
docs: Further update to multi-swap README.md to clarify the use of multi-swap and OOB swaps

### DIFF
--- a/src/multi-swap/README.md
+++ b/src/multi-swap/README.md
@@ -1,7 +1,7 @@
 
 This extension allows you to swap multiple elements marked with the `id` attribute from the HTML response. You can also choose for each element which [swap method](https://htmx.org/docs#swapping) should be used. Multi-swap is a very powerful tool in conjunction with `hx-boost` and `preload` extension.
 
-It should be noted that using OOB swaps ([Out of Band Swaps](https://htmx.org/docs#oob_swaps)) should be enough for most use cases, since OOB swaps by now can handle nested elements anywhere in the DOM and with a specified swap method. Thus it's recommended to be familiar with OOB swaps to make an informed decision on whether this extension is required anymore.
+It should be noted that using OOB swaps ([Out of Band Swaps](https://htmx.org/docs#oob_swaps)) should be enough for most use cases and a similar approach using the core htmx attributes is [`hx-select-oob`](https://htmx.org/attributes/hx-select-oob/) along with `hx-swap="none"`. Thus it's recommended to be familiar with OOB swaps to make an informed decision on whether this extension is required anymore.
 
 
 ## Install


### PR DESCRIPTION
## Description
Added an more explicit alternative to using multi-swap using `hx-select-oob`, so it's easier for non-experts to see the similarities between the two. Users often struggle with `hx-swap-oob` since they don't realise it's for the response html, and `hx-select-oob` is the more equivalent attribute as implied by the pre-existing issue.

Additionally, removed a clarification only useful in relation to the htmx v1 extension, whose documentation exists in the htmx repo, not here.

Htmx version: 2.x.x
Used extension(s) version(s): 2.x.x

Corresponding issue: #124, follow up to PR #148

## Testing
n/a

## Checklist

* [x] I have read the [contribution guidelines](https://github.com/bigskysoftware/htmx-extensions/blob/main/CONTRIBUTING.md)
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
