### PR TITLE
Mark preload event listeners as passive

### DIFF
--- a/src/preload/preload.js
+++ b/src/preload/preload.js
@@ -107,12 +107,12 @@
 
     // Set up event handlers listening for triggering events
     const needsTimeout = triggerEventName === 'mouseover'
-    node.addEventListener(triggerEventName, getEventHandler(node, needsTimeout))
+    node.addEventListener(triggerEventName, getEventHandler(node, needsTimeout), {passive: true})
 
     // Add `touchstart` listener for touchscreen support
     // if `mousedown` or `mouseover` is used
     if (triggerEventName === 'mousedown' || triggerEventName === 'mouseover') {
-      node.addEventListener('touchstart', getEventHandler(node))
+      node.addEventListener('touchstart', getEventHandler(node), {passive: true})
     }
 
     // If `mouseover` is used, set up `mouseout` listener,
@@ -123,7 +123,7 @@
         if ((evt.target === node) && (node.preloadState === 'TIMEOUT')) {
           node.preloadState = 'READY'
         }
-      })
+      }, {passive: true})
     }
 
     // Mark the node as ready to be preloaded


### PR DESCRIPTION
## Description

This marks the event listeners in the preload extension as passive to improve scroll performance.

Htmx version:
Used extension(s) version(s): 2.1.1

Resolves #154 

## Testing

I ran the test suite, but this change should have no noticeable effect.

## Checklist

* [x] I have read the [contribution guidelines](https://github.com/bigskysoftware/htmx-extensions/blob/main/CONTRIBUTING.md)
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
