### PR TITLE
fix case 161: websockets not closing

### DIFF
--- a/src/ws/test/ext/ws.js
+++ b/src/ws/test/ext/ws.js
@@ -25,7 +25,9 @@ describe('web-sockets extension', function() {
       close: function() {
         if (this._open) {
           this._open = false
-          this._fireEvent('close', { type: 'close', code: 0 })
+          setTimeout(function () {
+            this._fireEvent('close', { type: 'close', code: 1006 })
+          }.bind(this), 2)
         }
       },
       _listeners: {},
@@ -130,7 +132,7 @@ describe('web-sockets extension', function() {
     div.click()
     this.server.respond()
 
-    this.tickMock()
+    this.clock.tick(7000) // give socket opportunity to erroneously reconnect
 
     this.socketServer.clients().length.should.equal(0)
   })

--- a/src/ws/ws.js
+++ b/src/ws/ws.js
@@ -415,9 +415,8 @@ This extension adds support for WebSockets to htmx.  See /www/extensions/ws.md f
       var internalData = api.getInternalData(elt)
       if (internalData.webSocket) {
         internalData.webSocket.close()
-        return true
       }
-      return false
+      return true
     }
     return false
   }


### PR DESCRIPTION
This fixes case #161 by reverting a regression added from e87e1c3d0bf728b4e43861c7459f3f937883eb99

## Description
The above mentioned commit changed the return value meaning of `maybeCloseWebSocketSource` from "return true if socket should be closed" to "return true if I just closed the socket here and now".  This causes problems because an element that is swapping out will already have the socket closed and `webSocket` internal data removed when this function is called.  A "false" value is returned which will cause the `onClose` handler to erroneously reconnect the websocket.

Htmx version: 2.0.2 and 2.0.3


## Testing
- I tested this fix on my application using a patched version of htmx-ext-ws@2.0.3.
- Additionally, version 2.0.1 that predates e87e1c3d0bf728b4e43861c7459f3f937883eb99 did not have this issue.
- The existing automated tests actually do check for socket closing, however issue #161 does not occur in the test environment.  Fixing the test environment is beyond my knowledge.



## Checklist

* [x] I have read the [contribution guidelines](https://github.com/bigskysoftware/htmx-extensions/blob/main/CONTRIBUTING.md)
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
