### PR TITLE
SSE: allow custom swapping strategies (such as idiomorph) 

### DIFF
--- a/src/sse/sse.js
+++ b/src/sse/sse.js
@@ -280,7 +280,7 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 
     var swapSpec = api.getSwapSpecification(elt)
     var target = api.getTarget(elt)
-    api.swap(target, content, swapSpec)
+    api.swap(target, content, swapSpec, { contextElement: elt })
   }
 
 


### PR DESCRIPTION
## Description

Implemented the change described in #164 to include the `swapOptions.contextElement`-parameter with the `api.swap` call to ensure that HTMX extensions implementing custom swapping modes can be discovered from `hx-swap` tags in the DOM.

Htmx version: v2.0.4
Used extension(s) version(s): v2.2.3

Corresponding issue: #164 

## Testing

## Checklist

* [x] I have read the [contribution guidelines](https://github.com/bigskysoftware/htmx-extensions/blob/main/CONTRIBUTING.md)
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
