### PR TITLE
Attempt websocket reconnection on error code 1011 also

### DIFF
--- a/src/ws/ws.js
+++ b/src/ws/ws.js
@@ -253,7 +253,7 @@ This extension adds support for WebSockets to htmx.  See /www/extensions/ws.md f
         socket.onclose = function(e) {
           // If socket should not be connected, stop further attempts to establish connection
           // If Abnormal Closure/Service Restart/Try Again Later, then set a timer to reconnect after a pause.
-          if (!maybeCloseWebSocketSource(socketElt) && [1006, 1012, 1013].indexOf(e.code) >= 0) {
+          if (!maybeCloseWebSocketSource(socketElt) && [1006, 1011, 1012, 1013].indexOf(e.code) >= 0) {
             var delay = getWebSocketReconnectDelay(wrapper.retryCount)
             setTimeout(function() {
               wrapper.retryCount += 1


### PR DESCRIPTION
This error code (1011) is documented in RFC 6455, and it's what hunchensocket (a websocket server for Common Lisp) uses to signal websocket closure due to timeout.  I think that adding this to the list of error codes that triggers a reconnect is a small and reasonable change.

https://datatracker.ietf.org/doc/html/rfc6455

Search for 1011

## Description
I added the error code 1011 to the list of error codes the ws extension uses to determine whether it should try to reconnect the websocket.

Htmx version: 2.0.4
Used extension(s) version(s): 2.0.2 https://unpkg.com/htmx-ext-ws@2.0.2

Corresponding issue:

## Testing
- I reduced the timeout for websocket connections to 10 seconds while testing [gg/example](https://git.vern.cc/gg/example).
- I opened multiple browser tabs to localhost:4200 where the websocket server was running.
- I opened developer tools and watched the page successfully reconnect many times after the short timeout.

## Checklist

* [x] I have read the [contribution guidelines](https://github.com/bigskysoftware/htmx-extensions/blob/main/CONTRIBUTING.md)
* [x] I ran the test suite locally (`cd test/ws-sse; node server.mjs`) and verified that it succeeded
