### PR TITLE
Make jsDelivr CDN serve the same file as UNPKG

### DIFF
--- a/src/ajax-header/package.json
+++ b/src/ajax-header/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.2",
   "main": "dist/ajax-header.esm.js",
   "unpkg": "dist/ajax-header.min.js",
+  "jsdelivr": "dist/ajax-header.min.js",
   "scripts": {
     "lint": "eslint test/ext test",
     "lint-fix": "eslint test/ext test --fix",

--- a/src/alpine-morph/package.json
+++ b/src/alpine-morph/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.1",
   "main": "dist/alpine-morph.esm.js",
   "unpkg": "dist/alpine-morph.min.js",
+  "jsdelivr": "dist/alpine-morph.min.js",
   "scripts": {
     "lint": "eslint test/ext test",
     "lint-fix": "eslint test/ext test --fix",

--- a/src/class-tools/package.json
+++ b/src/class-tools/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.2",
   "main": "dist/class-tools.esm.js",
   "unpkg": "dist/pclass-tools.min.js",
+  "jsdelivr": "dist/pclass-tools.min.js",
   "scripts": {
     "lint": "eslint test/ext test",
     "lint-fix": "eslint test/ext test --fix",

--- a/src/client-side-templates/package.json
+++ b/src/client-side-templates/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.1",
   "main": "dist/client-side-templates.esm.js",
   "unpkg": "dist/client-side-templates.min.js",
+  "jsdelivr": "dist/client-side-templates.min.js",
   "scripts": {
     "lint": "eslint test/ext test",
     "lint-fix": "eslint test/ext test --fix",

--- a/src/debug/package.json
+++ b/src/debug/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.1",
   "main": "dist/debug.esm.js",
   "unpkg": "dist/debug.min.js",
+  "jsdelivr": "dist/debug.min.js",
   "scripts": {
     "lint": "eslint test/ext test",
     "lint-fix": "eslint test/ext test --fix",

--- a/src/disable-element/package.json
+++ b/src/disable-element/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.1",
   "main": "dist/disable-element.esm.js",
   "unpkg": "dist/disable-element.min.js",
+  "jsdelivr": "dist/disable-element.min.js",
   "scripts": {
     "lint": "eslint test/ext test",
     "lint-fix": "eslint test/ext test --fix",

--- a/src/event-header/package.json
+++ b/src/event-header/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.1",
   "main": "dist/event-header.esm.js",
   "unpkg": "dist/event-header.min.js",
+  "jsdelivr": "dist/event-header.min.js",
   "scripts": {
     "lint": "eslint test/ext test",
     "lint-fix": "eslint test/ext test --fix",

--- a/src/head-support/package.json
+++ b/src/head-support/package.json
@@ -4,6 +4,7 @@
   "homepage": "https://htmx.org/extensions/head-support/",
   "main": "dist/head-support.esm.js",
   "unpkg": "dist/head-support.min.js",
+  "jsdelivr": "dist/head-support.min.js",
   "scripts": {
     "lint": "eslint test/ext test",
     "lint-fix": "eslint test/ext test --fix",

--- a/src/htmx-1-compat/package.json
+++ b/src/htmx-1-compat/package.json
@@ -4,6 +4,7 @@
   "homepage": "https://htmx.org/extensions/htmx-1-compat/",
   "main": "dist/htmx-1-compat.esm.js",
   "unpkg": "dist/htmx-1-compat.min.js",
+  "jsdelivr": "dist/htmx-1-compat.min.js",
   "scripts": {
     "lint": "eslint test/ext test",
     "lint-fix": "eslint test/ext test --fix",

--- a/src/include-vals/package.json
+++ b/src/include-vals/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.1",
   "main": "dist/include-vals.esm.js",
   "unpkg": "dist/include-vals.min.js",
+  "jsdelivr": "dist/include-vals.min.js",
   "scripts": {
     "lint": "eslint test/ext test",
     "lint-fix": "eslint test/ext test --fix",

--- a/src/json-enc/package.json
+++ b/src/json-enc/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.2",
   "main": "dist/json-enc.esm.js",
   "unpkg": "dist/json-enc.min.js",
+  "jsdelivr": "dist/json-enc.min.js",
   "scripts": {
     "lint": "eslint test/ext test",
     "lint-fix": "eslint test/ext test --fix",

--- a/src/loading-states/package.json
+++ b/src/loading-states/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.1",
   "main": "dist/loading-states.esm.js",
   "unpkg": "dist/loading-states.min.js",
+  "jsdelivr": "dist/loading-states.min.js",
   "scripts": {
     "lint": "eslint test/ext test",
     "lint-fix": "eslint test/ext test --fix",

--- a/src/method-override/package.json
+++ b/src/method-override/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.2",
   "main": "dist/method-override.esm.js",
   "unpkg": "dist/method-override.min.js",
+  "jsdelivr": "dist/method-override.min.js",
   "scripts": {
     "lint": "eslint test/ext test",
     "lint-fix": "eslint test/ext test --fix",

--- a/src/morphdom-swap/package.json
+++ b/src/morphdom-swap/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.1",
   "main": "dist/morphdom-swap.esm.js",
   "unpkg": "dist/morphdom-swap.min.js",
+  "jsdelivr": "dist/morphdom-swap.min.js",
   "scripts": {
     "lint": "eslint test/ext test",
     "lint-fix": "eslint test/ext test --fix",

--- a/src/multi-swap/package.json
+++ b/src/multi-swap/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.1",
   "main": "dist/multi-swap.esm.js",
   "unpkg": "dist/multi-swap.min.js",
+  "jsdelivr": "dist/multi-swap.min.js",
   "scripts": {
     "lint": "eslint test/ext test",
     "lint-fix": "eslint test/ext test --fix",

--- a/src/path-deps/package.json
+++ b/src/path-deps/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.1",
   "main": "dist/path-deps.esm.js",
   "unpkg": "dist/path-deps.min.js",
+  "jsdelivr": "dist/path-deps.min.js",
   "scripts": {
     "lint": "eslint test/ext test",
     "lint-fix": "eslint test/ext test --fix",

--- a/src/path-params/package.json
+++ b/src/path-params/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.1",
   "main": "dist/path-params.esm.js",
   "unpkg": "dist/path-params.min.js",
+  "jsdelivr": "dist/path-params.min.js",
   "scripts": {
     "lint": "eslint test/ext test",
     "lint-fix": "eslint test/ext test --fix",

--- a/src/preload/package.json
+++ b/src/preload/package.json
@@ -4,6 +4,7 @@
   "homepage": "https://htmx.org/extensions/preload/",
   "main": "dist/preload.esm.js",
   "unpkg": "dist/preload.min.js",
+  "jsdelivr": "dist/preload.min.js",
   "scripts": {
     "lint": "eslint test/ext test",
     "lint-fix": "eslint test/ext test --fix",

--- a/src/remove-me/package.json
+++ b/src/remove-me/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.1",
   "main": "dist/remove-me.esm.js",
   "unpkg": "dist/remove-me.min.js",
+  "jsdelivr": "dist/remove-me.min.js",
   "scripts": {
     "lint": "eslint test/ext test",
     "lint-fix": "eslint test/ext test --fix",

--- a/src/response-targets/package.json
+++ b/src/response-targets/package.json
@@ -4,6 +4,7 @@
   "homepage": "https://htmx.org/extensions/response-targets/",
   "main": "dist/response-targets.esm.js",
   "unpkg": "dist/response-targets.min.js",
+  "jsdelivr": "dist/response-targets.min.js",
   "scripts": {
     "lint": "eslint test/ext test",
     "lint-fix": "eslint test/ext test --fix",

--- a/src/restored/package.json
+++ b/src/restored/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.1",
   "main": "dist/restored.esm.js",
   "unpkg": "dist/restored.min.js",
+  "jsdelivr": "dist/restored.min.js",
   "scripts": {
     "lint": "eslint test/ext test",
     "lint-fix": "eslint test/ext test --fix",

--- a/src/sse/package.json
+++ b/src/sse/package.json
@@ -4,6 +4,7 @@
   "homepage": "https://htmx.org/extensions/sse/",
   "main": "dist/sse.esm.js",
   "unpkg": "dist/sse.min.js",
+  "jsdelivr": "dist/sse.min.js",
   "scripts": {
     "lint": "eslint test/ext test",
     "lint-fix": "eslint test/ext test --fix",

--- a/src/ws/package.json
+++ b/src/ws/package.json
@@ -4,6 +4,7 @@
   "homepage": "https://htmx.org/extensions/ws/",
   "main": "dist/ws.esm.js",
   "unpkg": "dist/ws.min.js",
+  "jsdelivr": "dist/ws.min.js",
   "scripts": {
     "lint": "eslint test/ext test",
     "lint-fix": "eslint test/ext test --fix",


### PR DESCRIPTION
## Description
Currently jsDelivr is referenced on the htmx site, but some serve the esm version.
e.g. `https://cdn.jsdelivr.net/npm/htmx-ext-head-support` mentioned in https://htmx.org/extensions/head-support/
e.g. `https://cdn.jsdelivr.net/npm/htmx-ext-response-targets@2.0.2` mentioned in https://htmx.org/docs/

This PR updates each extension's `package.json` so that there is a value for `jsdelivr` in addition to the existing `unpkg` one.

Htmx version: latest (n/a)
Used extension(s) version(s): n/a

Corresponding issue: https://github.com/bigskysoftware/htmx/issues/3380

## Testing
I ran `npm install` for each extension to verify that the `package.json` is still valid.
The final check will be looking at the CDN when new versions of the extensions are released.

## Checklist

* [x] I have read the [contribution guidelines](https://github.com/bigskysoftware/htmx-extensions/blob/main/CONTRIBUTING.md)
* [ ] I ran the test suite locally (`npm run test`) and verified that it succeeded
