### PR TITLE
Make htmx a peer dependency of each extension

### DIFF
--- a/src/ajax-header/package-lock.json
+++ b/src/ajax-header/package-lock.json
@@ -7,36 +7,36 @@
     "": {
       "name": "htmx-ext-ajax-header",
       "version": "2.0.2",
-      "dependencies": {
-        "htmx.org": "^2.0.2"
-      },
       "devDependencies": {
         "chai": "^4.3.10",
         "chai-dom": "^1.12.0",
         "mocha": "10.1.0",
         "mocha-chrome": "https://github.com/Telroshan/mocha-chrome",
         "sinon": "^9.2.4"
+      },
+      "peerDependencies": {
+        "htmx.org": "^2.0.2"
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.27.1",
         "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -100,13 +100,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.13.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.2.tgz",
-      "integrity": "sha512-Z+r8y3XL9ZpI2EY52YYygAFmo2/oWfNSj4BCpAXE2McAexDk8VcnBMGC9Djn9gTKt4d2T/hhXqmPzo4hfIXtTg==",
+      "version": "24.0.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.15.tgz",
+      "integrity": "sha512-oaeTSbCef7U/z7rDeJA138xpG3NuKc64/rZ2qmUFkFJmnMsAPaluIifqyWd8hSSMxyP9oie3dLAqYPblag9KgA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~7.8.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -214,9 +214,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -761,9 +761,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -841,10 +841,11 @@
       }
     },
     "node_modules/htmx.org": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.4.tgz",
-      "integrity": "sha512-HLxMCdfXDOJirs3vBZl/ZLoY+c7PfM4Ahr2Ad4YXh6d22T5ltbTXFFkpx9Tgb2vvmWFMbIc3LqN2ToNkZJvyYQ==",
-      "license": "0BSD"
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.6.tgz",
+      "integrity": "sha512-7ythjYneGSk3yCHgtCnQeaoF+D+o7U2LF37WU3O0JYv3gTZSicdEFiI/Ai/NJyC5ZpYJWMpUb11OC5Lr6AfAqA==",
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/import-local": {
       "version": "3.2.0",
@@ -1214,9 +1215,9 @@
       }
     },
     "node_modules/marky": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/marky/-/marky-1.2.5.tgz",
-      "integrity": "sha512-q9JtQJKjpsVxCRVgQ+WapguSbKC3SQ5HEzFGPAJMStgh3QjCawp00UKv3MTTAArTmGmmPUvllHZoNbZ3gs0I+Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
+      "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -1825,9 +1826,9 @@
       }
     },
     "node_modules/read-pkg-up/node_modules/yocto-queue": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.1.1.tgz",
-      "integrity": "sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
+      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1984,9 +1985,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -2208,9 +2209,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
       "dev": true,
       "license": "MIT"
     },

--- a/src/ajax-header/package.json
+++ b/src/ajax-header/package.json
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "git+https://github.com/bigskysoftware/htmx-extensions.git"
   },
-  "dependencies": {
+  "peerDependencies": {
     "htmx.org": "^2.0.2"
   },
   "devDependencies": {

--- a/src/alpine-morph/package-lock.json
+++ b/src/alpine-morph/package-lock.json
@@ -7,15 +7,15 @@
     "": {
       "name": "htmx-ext-alpine-morph",
       "version": "2.0.1",
-      "dependencies": {
-        "htmx.org": "^2.0.2"
-      },
       "devDependencies": {
         "chai": "^4.3.10",
         "chai-dom": "^1.12.0",
         "mocha": "10.1.0",
         "mocha-chrome": "https://github.com/Telroshan/mocha-chrome",
         "sinon": "^9.2.4"
+      },
+      "peerDependencies": {
+        "htmx.org": "^2.0.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -844,7 +844,8 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.4.tgz",
       "integrity": "sha512-HLxMCdfXDOJirs3vBZl/ZLoY+c7PfM4Ahr2Ad4YXh6d22T5ltbTXFFkpx9Tgb2vvmWFMbIc3LqN2ToNkZJvyYQ==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/import-local": {
       "version": "3.2.0",

--- a/src/alpine-morph/package.json
+++ b/src/alpine-morph/package.json
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "git+https://github.com/bigskysoftware/htmx-extensions.git"
   },
-  "dependencies": {
+  "peerDependencies": {
     "htmx.org": "^2.0.2"
   },
   "devDependencies": {

--- a/src/class-tools/package-lock.json
+++ b/src/class-tools/package-lock.json
@@ -7,15 +7,15 @@
     "": {
       "name": "htmx-ext-class-tools",
       "version": "2.0.2",
-      "dependencies": {
-        "htmx.org": "^2.0.2"
-      },
       "devDependencies": {
         "chai": "^4.3.10",
         "chai-dom": "^1.12.0",
         "mocha": "10.1.0",
         "mocha-chrome": "https://github.com/Telroshan/mocha-chrome",
         "sinon": "^9.2.4"
+      },
+      "peerDependencies": {
+        "htmx.org": "^2.0.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -844,7 +844,8 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.4.tgz",
       "integrity": "sha512-HLxMCdfXDOJirs3vBZl/ZLoY+c7PfM4Ahr2Ad4YXh6d22T5ltbTXFFkpx9Tgb2vvmWFMbIc3LqN2ToNkZJvyYQ==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/import-local": {
       "version": "3.2.0",

--- a/src/class-tools/package.json
+++ b/src/class-tools/package.json
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "git+https://github.com/bigskysoftware/htmx-extensions.git"
   },
-  "dependencies": {
+  "peerDependencies": {
     "htmx.org": "^2.0.2"
   },
   "devDependencies": {

--- a/src/client-side-templates/package-lock.json
+++ b/src/client-side-templates/package-lock.json
@@ -7,15 +7,15 @@
     "": {
       "name": "htmx-ext-client-side-templates",
       "version": "2.0.1",
-      "dependencies": {
-        "htmx.org": "^2.0.2"
-      },
       "devDependencies": {
         "chai": "^4.3.10",
         "chai-dom": "^1.12.0",
         "mocha": "10.1.0",
         "mocha-chrome": "https://github.com/Telroshan/mocha-chrome",
         "sinon": "^9.2.4"
+      },
+      "peerDependencies": {
+        "htmx.org": "^2.0.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -844,7 +844,8 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.4.tgz",
       "integrity": "sha512-HLxMCdfXDOJirs3vBZl/ZLoY+c7PfM4Ahr2Ad4YXh6d22T5ltbTXFFkpx9Tgb2vvmWFMbIc3LqN2ToNkZJvyYQ==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/import-local": {
       "version": "3.2.0",

--- a/src/client-side-templates/package.json
+++ b/src/client-side-templates/package.json
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "git+https://github.com/bigskysoftware/htmx-extensions.git"
   },
-  "dependencies": {
+  "peerDependencies": {
     "htmx.org": "^2.0.2"
   },
   "devDependencies": {

--- a/src/debug/package-lock.json
+++ b/src/debug/package-lock.json
@@ -7,15 +7,15 @@
     "": {
       "name": "htmx-ext-debug",
       "version": "2.0.1",
-      "dependencies": {
-        "htmx.org": "^2.0.2"
-      },
       "devDependencies": {
         "chai": "^4.3.10",
         "chai-dom": "^1.12.0",
         "mocha": "10.1.0",
         "mocha-chrome": "https://github.com/Telroshan/mocha-chrome",
         "sinon": "^9.2.4"
+      },
+      "peerDependencies": {
+        "htmx.org": "^2.0.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -844,7 +844,8 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.4.tgz",
       "integrity": "sha512-HLxMCdfXDOJirs3vBZl/ZLoY+c7PfM4Ahr2Ad4YXh6d22T5ltbTXFFkpx9Tgb2vvmWFMbIc3LqN2ToNkZJvyYQ==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/import-local": {
       "version": "3.2.0",

--- a/src/debug/package.json
+++ b/src/debug/package.json
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "git+https://github.com/bigskysoftware/htmx-extensions.git"
   },
-  "dependencies": {
+  "peerDependencies": {
     "htmx.org": "^2.0.2"
   },
   "devDependencies": {

--- a/src/disable-element/package-lock.json
+++ b/src/disable-element/package-lock.json
@@ -7,15 +7,15 @@
     "": {
       "name": "htmx-ext-disable-element",
       "version": "2.0.1",
-      "dependencies": {
-        "htmx.org": "^2.0.2"
-      },
       "devDependencies": {
         "chai": "^4.3.10",
         "chai-dom": "^1.12.0",
         "mocha": "10.1.0",
         "mocha-chrome": "https://github.com/Telroshan/mocha-chrome",
         "sinon": "^9.2.4"
+      },
+      "peerDependencies": {
+        "htmx.org": "^2.0.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -844,7 +844,8 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.4.tgz",
       "integrity": "sha512-HLxMCdfXDOJirs3vBZl/ZLoY+c7PfM4Ahr2Ad4YXh6d22T5ltbTXFFkpx9Tgb2vvmWFMbIc3LqN2ToNkZJvyYQ==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/import-local": {
       "version": "3.2.0",

--- a/src/disable-element/package.json
+++ b/src/disable-element/package.json
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "git+https://github.com/bigskysoftware/htmx-extensions.git"
   },
-  "dependencies": {
+  "peerDependencies": {
     "htmx.org": "^2.0.2"
   },
   "devDependencies": {

--- a/src/event-header/package-lock.json
+++ b/src/event-header/package-lock.json
@@ -7,15 +7,15 @@
     "": {
       "name": "htmx-ext-event-header",
       "version": "2.0.1",
-      "dependencies": {
-        "htmx.org": "^2.0.2"
-      },
       "devDependencies": {
         "chai": "^4.3.10",
         "chai-dom": "^1.12.0",
         "mocha": "10.1.0",
         "mocha-chrome": "https://github.com/Telroshan/mocha-chrome",
         "sinon": "^9.2.4"
+      },
+      "peerDependencies": {
+        "htmx.org": "^2.0.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -844,7 +844,8 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.4.tgz",
       "integrity": "sha512-HLxMCdfXDOJirs3vBZl/ZLoY+c7PfM4Ahr2Ad4YXh6d22T5ltbTXFFkpx9Tgb2vvmWFMbIc3LqN2ToNkZJvyYQ==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/import-local": {
       "version": "3.2.0",

--- a/src/event-header/package.json
+++ b/src/event-header/package.json
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "git+https://github.com/bigskysoftware/htmx-extensions.git"
   },
-  "dependencies": {
+  "peerDependencies": {
     "htmx.org": "^2.0.2"
   },
   "devDependencies": {

--- a/src/head-support/package-lock.json
+++ b/src/head-support/package-lock.json
@@ -8,15 +8,15 @@
       "name": "htmx-ext-head-support",
       "version": "2.0.4",
       "license": "0BSD",
-      "dependencies": {
-        "htmx.org": "^2.0.2"
-      },
       "devDependencies": {
         "chai": "^4.3.10",
         "chai-dom": "^1.12.0",
         "mocha": "10.1.0",
         "mocha-chrome": "https://github.com/Telroshan/mocha-chrome",
         "sinon": "^9.2.4"
+      },
+      "peerDependencies": {
+        "htmx.org": "^2.0.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -845,7 +845,8 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.4.tgz",
       "integrity": "sha512-HLxMCdfXDOJirs3vBZl/ZLoY+c7PfM4Ahr2Ad4YXh6d22T5ltbTXFFkpx9Tgb2vvmWFMbIc3LqN2ToNkZJvyYQ==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/import-local": {
       "version": "3.2.0",

--- a/src/head-support/package.json
+++ b/src/head-support/package.json
@@ -16,7 +16,7 @@
     "type": "git",
     "url": "git+https://github.com/bigskysoftware/htmx-extensions.git"
   },
-  "dependencies": {
+  "peerDependencies": {
     "htmx.org": "^2.0.2"
   },
   "devDependencies": {

--- a/src/htmx-1-compat/package-lock.json
+++ b/src/htmx-1-compat/package-lock.json
@@ -7,15 +7,15 @@
     "": {
       "name": "htmx-ext-htmx-1-compat",
       "version": "2.0.1",
-      "dependencies": {
-        "htmx.org": "^2.0.2"
-      },
       "devDependencies": {
         "chai": "^4.3.10",
         "chai-dom": "^1.12.0",
         "mocha": "10.1.0",
         "mocha-chrome": "https://github.com/Telroshan/mocha-chrome",
         "sinon": "^9.2.4"
+      },
+      "peerDependencies": {
+        "htmx.org": "^2.0.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -844,7 +844,8 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.4.tgz",
       "integrity": "sha512-HLxMCdfXDOJirs3vBZl/ZLoY+c7PfM4Ahr2Ad4YXh6d22T5ltbTXFFkpx9Tgb2vvmWFMbIc3LqN2ToNkZJvyYQ==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/import-local": {
       "version": "3.2.0",

--- a/src/htmx-1-compat/package.json
+++ b/src/htmx-1-compat/package.json
@@ -16,7 +16,7 @@
     "type": "git",
     "url": "git+https://github.com/bigskysoftware/htmx-extensions.git"
   },
-  "dependencies": {
+  "peerDependencies": {
     "htmx.org": "^2.0.2"
   },
   "devDependencies": {

--- a/src/include-vals/package-lock.json
+++ b/src/include-vals/package-lock.json
@@ -7,15 +7,15 @@
     "": {
       "name": "htmx-ext-include-vals",
       "version": "2.0.1",
-      "dependencies": {
-        "htmx.org": "^2.0.2"
-      },
       "devDependencies": {
         "chai": "^4.3.10",
         "chai-dom": "^1.12.0",
         "mocha": "10.1.0",
         "mocha-chrome": "https://github.com/Telroshan/mocha-chrome",
         "sinon": "^9.2.4"
+      },
+      "peerDependencies": {
+        "htmx.org": "^2.0.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -844,7 +844,8 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.4.tgz",
       "integrity": "sha512-HLxMCdfXDOJirs3vBZl/ZLoY+c7PfM4Ahr2Ad4YXh6d22T5ltbTXFFkpx9Tgb2vvmWFMbIc3LqN2ToNkZJvyYQ==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/import-local": {
       "version": "3.2.0",

--- a/src/include-vals/package.json
+++ b/src/include-vals/package.json
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "git+https://github.com/bigskysoftware/htmx-extensions.git"
   },
-  "dependencies": {
+  "peerDependencies": {
     "htmx.org": "^2.0.2"
   },
   "devDependencies": {

--- a/src/json-enc/package-lock.json
+++ b/src/json-enc/package-lock.json
@@ -7,15 +7,15 @@
     "": {
       "name": "htmx-ext-json-enc",
       "version": "2.0.2",
-      "dependencies": {
-        "htmx.org": "^2.0.2"
-      },
       "devDependencies": {
         "chai": "^4.3.10",
         "chai-dom": "^1.12.0",
         "mocha": "10.1.0",
         "mocha-chrome": "https://github.com/Telroshan/mocha-chrome",
         "sinon": "^9.2.4"
+      },
+      "peerDependencies": {
+        "htmx.org": "^2.0.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -844,7 +844,8 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.4.tgz",
       "integrity": "sha512-HLxMCdfXDOJirs3vBZl/ZLoY+c7PfM4Ahr2Ad4YXh6d22T5ltbTXFFkpx9Tgb2vvmWFMbIc3LqN2ToNkZJvyYQ==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/import-local": {
       "version": "3.2.0",

--- a/src/json-enc/package.json
+++ b/src/json-enc/package.json
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "git+https://github.com/bigskysoftware/htmx-extensions.git"
   },
-  "dependencies": {
+  "peerDependencies": {
     "htmx.org": "^2.0.2"
   },
   "devDependencies": {

--- a/src/loading-states/package-lock.json
+++ b/src/loading-states/package-lock.json
@@ -7,15 +7,15 @@
     "": {
       "name": "htmx-ext-loading-states",
       "version": "2.0.1",
-      "dependencies": {
-        "htmx.org": "^2.0.2"
-      },
       "devDependencies": {
         "chai": "^4.3.10",
         "chai-dom": "^1.12.0",
         "mocha": "10.1.0",
         "mocha-chrome": "https://github.com/Telroshan/mocha-chrome",
         "sinon": "^9.2.4"
+      },
+      "peerDependencies": {
+        "htmx.org": "^2.0.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -844,7 +844,8 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.4.tgz",
       "integrity": "sha512-HLxMCdfXDOJirs3vBZl/ZLoY+c7PfM4Ahr2Ad4YXh6d22T5ltbTXFFkpx9Tgb2vvmWFMbIc3LqN2ToNkZJvyYQ==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/import-local": {
       "version": "3.2.0",

--- a/src/loading-states/package.json
+++ b/src/loading-states/package.json
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "git+https://github.com/bigskysoftware/htmx-extensions.git"
   },
-  "dependencies": {
+  "peerDependencies": {
     "htmx.org": "^2.0.2"
   },
   "devDependencies": {

--- a/src/method-override/package-lock.json
+++ b/src/method-override/package-lock.json
@@ -7,15 +7,15 @@
     "": {
       "name": "htmx-ext-method-override",
       "version": "2.0.2",
-      "dependencies": {
-        "htmx.org": "^2.0.2"
-      },
       "devDependencies": {
         "chai": "^4.3.10",
         "chai-dom": "^1.12.0",
         "mocha": "10.1.0",
         "mocha-chrome": "https://github.com/Telroshan/mocha-chrome",
         "sinon": "^9.2.4"
+      },
+      "peerDependencies": {
+        "htmx.org": "^2.0.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -844,7 +844,8 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.4.tgz",
       "integrity": "sha512-HLxMCdfXDOJirs3vBZl/ZLoY+c7PfM4Ahr2Ad4YXh6d22T5ltbTXFFkpx9Tgb2vvmWFMbIc3LqN2ToNkZJvyYQ==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/import-local": {
       "version": "3.2.0",

--- a/src/method-override/package.json
+++ b/src/method-override/package.json
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "git+https://github.com/bigskysoftware/htmx-extensions.git"
   },
-  "dependencies": {
+  "peerDependencies": {
     "htmx.org": "^2.0.2"
   },
   "devDependencies": {

--- a/src/morphdom-swap/package-lock.json
+++ b/src/morphdom-swap/package-lock.json
@@ -7,15 +7,15 @@
     "": {
       "name": "htmx-ext-morphdom-swap",
       "version": "2.0.1",
-      "dependencies": {
-        "htmx.org": "^2.0.2"
-      },
       "devDependencies": {
         "chai": "^4.3.10",
         "chai-dom": "^1.12.0",
         "mocha": "10.1.0",
         "mocha-chrome": "https://github.com/Telroshan/mocha-chrome",
         "sinon": "^9.2.4"
+      },
+      "peerDependencies": {
+        "htmx.org": "^2.0.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -844,7 +844,8 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.4.tgz",
       "integrity": "sha512-HLxMCdfXDOJirs3vBZl/ZLoY+c7PfM4Ahr2Ad4YXh6d22T5ltbTXFFkpx9Tgb2vvmWFMbIc3LqN2ToNkZJvyYQ==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/import-local": {
       "version": "3.2.0",

--- a/src/morphdom-swap/package.json
+++ b/src/morphdom-swap/package.json
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "git+https://github.com/bigskysoftware/htmx-extensions.git"
   },
-  "dependencies": {
+  "peerDependencies": {
     "htmx.org": "^2.0.2"
   },
   "devDependencies": {

--- a/src/multi-swap/package-lock.json
+++ b/src/multi-swap/package-lock.json
@@ -7,15 +7,15 @@
     "": {
       "name": "htmx-ext-multi-swap",
       "version": "2.0.1",
-      "dependencies": {
-        "htmx.org": "^2.0.2"
-      },
       "devDependencies": {
         "chai": "^4.3.10",
         "chai-dom": "^1.12.0",
         "mocha": "10.1.0",
         "mocha-chrome": "https://github.com/Telroshan/mocha-chrome",
         "sinon": "^9.2.4"
+      },
+      "peerDependencies": {
+        "htmx.org": "^2.0.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -844,7 +844,8 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.4.tgz",
       "integrity": "sha512-HLxMCdfXDOJirs3vBZl/ZLoY+c7PfM4Ahr2Ad4YXh6d22T5ltbTXFFkpx9Tgb2vvmWFMbIc3LqN2ToNkZJvyYQ==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/import-local": {
       "version": "3.2.0",

--- a/src/multi-swap/package.json
+++ b/src/multi-swap/package.json
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "git+https://github.com/bigskysoftware/htmx-extensions.git"
   },
-  "dependencies": {
+  "peerDependencies": {
     "htmx.org": "^2.0.2"
   },
   "devDependencies": {

--- a/src/path-deps/package-lock.json
+++ b/src/path-deps/package-lock.json
@@ -7,15 +7,15 @@
     "": {
       "name": "htmx-ext-path-deps",
       "version": "2.0.1",
-      "dependencies": {
-        "htmx.org": "^2.0.2"
-      },
       "devDependencies": {
         "chai": "^4.3.10",
         "chai-dom": "^1.12.0",
         "mocha": "10.1.0",
         "mocha-chrome": "https://github.com/Telroshan/mocha-chrome",
         "sinon": "^9.2.4"
+      },
+      "peerDependencies": {
+        "htmx.org": "^2.0.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -844,7 +844,8 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.4.tgz",
       "integrity": "sha512-HLxMCdfXDOJirs3vBZl/ZLoY+c7PfM4Ahr2Ad4YXh6d22T5ltbTXFFkpx9Tgb2vvmWFMbIc3LqN2ToNkZJvyYQ==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/import-local": {
       "version": "3.2.0",

--- a/src/path-deps/package.json
+++ b/src/path-deps/package.json
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "git+https://github.com/bigskysoftware/htmx-extensions.git"
   },
-  "dependencies": {
+  "peerDependencies": {
     "htmx.org": "^2.0.2"
   },
   "devDependencies": {

--- a/src/path-params/package-lock.json
+++ b/src/path-params/package-lock.json
@@ -7,15 +7,15 @@
     "": {
       "name": "htmx-ext-path-params",
       "version": "2.0.1",
-      "dependencies": {
-        "htmx.org": "^2.0.2"
-      },
       "devDependencies": {
         "chai": "^4.3.10",
         "chai-dom": "^1.12.0",
         "mocha": "10.1.0",
         "mocha-chrome": "https://github.com/Telroshan/mocha-chrome",
         "sinon": "^9.2.4"
+      },
+      "peerDependencies": {
+        "htmx.org": "^2.0.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -844,7 +844,8 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.4.tgz",
       "integrity": "sha512-HLxMCdfXDOJirs3vBZl/ZLoY+c7PfM4Ahr2Ad4YXh6d22T5ltbTXFFkpx9Tgb2vvmWFMbIc3LqN2ToNkZJvyYQ==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/import-local": {
       "version": "3.2.0",

--- a/src/path-params/package.json
+++ b/src/path-params/package.json
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "git+https://github.com/bigskysoftware/htmx-extensions.git"
   },
-  "dependencies": {
+  "peerDependencies": {
     "htmx.org": "^2.0.2"
   },
   "devDependencies": {

--- a/src/preload/package-lock.json
+++ b/src/preload/package-lock.json
@@ -7,15 +7,15 @@
     "": {
       "name": "htmx-ext-preload",
       "version": "2.1.1",
-      "dependencies": {
-        "htmx.org": "^2.0.3"
-      },
       "devDependencies": {
         "chai": "^4.3.10",
         "chai-dom": "^1.12.0",
         "mocha": "10.1.0",
         "mocha-chrome": "https://github.com/Telroshan/mocha-chrome",
         "sinon": "^9.2.4"
+      },
+      "peerDependencies": {
+        "htmx.org": "^2.0.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -844,7 +844,8 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.4.tgz",
       "integrity": "sha512-HLxMCdfXDOJirs3vBZl/ZLoY+c7PfM4Ahr2Ad4YXh6d22T5ltbTXFFkpx9Tgb2vvmWFMbIc3LqN2ToNkZJvyYQ==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/import-local": {
       "version": "3.2.0",

--- a/src/preload/package.json
+++ b/src/preload/package.json
@@ -16,7 +16,7 @@
     "type": "git",
     "url": "git+https://github.com/bigskysoftware/htmx-extensions.git"
   },
-  "dependencies": {
+  "peerDependencies": {
     "htmx.org": "^2.0.3"
   },
   "devDependencies": {

--- a/src/remove-me/package-lock.json
+++ b/src/remove-me/package-lock.json
@@ -7,15 +7,15 @@
     "": {
       "name": "htmx-ext-remove-me",
       "version": "2.0.1",
-      "dependencies": {
-        "htmx.org": "^2.0.2"
-      },
       "devDependencies": {
         "chai": "^4.3.10",
         "chai-dom": "^1.12.0",
         "mocha": "10.1.0",
         "mocha-chrome": "https://github.com/Telroshan/mocha-chrome",
         "sinon": "^9.2.4"
+      },
+      "peerDependencies": {
+        "htmx.org": "^2.0.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -844,7 +844,8 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.4.tgz",
       "integrity": "sha512-HLxMCdfXDOJirs3vBZl/ZLoY+c7PfM4Ahr2Ad4YXh6d22T5ltbTXFFkpx9Tgb2vvmWFMbIc3LqN2ToNkZJvyYQ==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/import-local": {
       "version": "3.2.0",

--- a/src/remove-me/package.json
+++ b/src/remove-me/package.json
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "git+https://github.com/bigskysoftware/htmx-extensions.git"
   },
-  "dependencies": {
+  "peerDependencies": {
     "htmx.org": "^2.0.2"
   },
   "devDependencies": {

--- a/src/response-targets/package-lock.json
+++ b/src/response-targets/package-lock.json
@@ -7,15 +7,15 @@
     "": {
       "name": "htmx-ext-response-targets",
       "version": "2.0.3",
-      "dependencies": {
-        "htmx.org": "^2.0.2"
-      },
       "devDependencies": {
         "chai": "^4.3.10",
         "chai-dom": "^1.12.0",
         "mocha": "10.1.0",
         "mocha-chrome": "https://github.com/Telroshan/mocha-chrome",
         "sinon": "^9.2.4"
+      },
+      "peerDependencies": {
+        "htmx.org": "^2.0.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -844,7 +844,8 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.4.tgz",
       "integrity": "sha512-HLxMCdfXDOJirs3vBZl/ZLoY+c7PfM4Ahr2Ad4YXh6d22T5ltbTXFFkpx9Tgb2vvmWFMbIc3LqN2ToNkZJvyYQ==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/import-local": {
       "version": "3.2.0",

--- a/src/response-targets/package.json
+++ b/src/response-targets/package.json
@@ -16,7 +16,7 @@
     "type": "git",
     "url": "git+https://github.com/bigskysoftware/htmx-extensions.git"
   },
-  "dependencies": {
+  "peerDependencies": {
     "htmx.org": "^2.0.2"
   },
   "devDependencies": {

--- a/src/restored/package-lock.json
+++ b/src/restored/package-lock.json
@@ -7,9 +7,6 @@
     "": {
       "name": "htmx-ext-restored",
       "version": "2.0.1",
-      "dependencies": {
-        "htmx.org": "^2.0.2"
-      },
       "devDependencies": {
         "chai": "^4.3.10",
         "chai-dom": "^1.12.0",
@@ -17,6 +14,9 @@
         "mocha": "10.1.0",
         "mocha-chrome": "https://github.com/Telroshan/mocha-chrome",
         "sinon": "^9.2.4"
+      },
+      "peerDependencies": {
+        "htmx.org": "^2.0.2"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/src/restored/package.json
+++ b/src/restored/package.json
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "git+https://github.com/bigskysoftware/htmx-extensions.git"
   },
-  "dependencies": {
+  "peerDependencies": {
     "htmx.org": "^2.0.2"
   },
   "devDependencies": {

--- a/src/sse/package-lock.json
+++ b/src/sse/package-lock.json
@@ -7,9 +7,6 @@
     "": {
       "name": "htmx-ext-sse",
       "version": "2.2.3",
-      "dependencies": {
-        "htmx.org": "^2.0.2"
-      },
       "devDependencies": {
         "chai": "^4.3.10",
         "chai-dom": "^1.12.0",
@@ -17,6 +14,9 @@
         "mocha": "10.1.0",
         "mocha-chrome": "https://github.com/Telroshan/mocha-chrome",
         "sinon": "^9.2.4"
+      },
+      "peerDependencies": {
+        "htmx.org": "^2.0.2"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/src/sse/package.json
+++ b/src/sse/package.json
@@ -16,7 +16,7 @@
     "type": "git",
     "url": "git+https://github.com/bigskysoftware/htmx-extensions.git"
   },
-  "dependencies": {
+  "peerDependencies": {
     "htmx.org": "^2.0.2"
   },
   "devDependencies": {

--- a/src/ws/package-lock.json
+++ b/src/ws/package-lock.json
@@ -7,9 +7,6 @@
     "": {
       "name": "htmx-ext-ws",
       "version": "2.0.3",
-      "dependencies": {
-        "htmx.org": "^2.0.2"
-      },
       "devDependencies": {
         "chai": "^4.3.10",
         "chai-dom": "^1.12.0",
@@ -17,6 +14,9 @@
         "mocha-chrome": "https://github.com/Telroshan/mocha-chrome",
         "mock-socket": "^9.3.1",
         "sinon": "^9.2.4"
+      },
+      "peerDependencies": {
+        "htmx.org": "^2.0.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -845,7 +845,8 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/htmx.org/-/htmx.org-2.0.4.tgz",
       "integrity": "sha512-HLxMCdfXDOJirs3vBZl/ZLoY+c7PfM4Ahr2Ad4YXh6d22T5ltbTXFFkpx9Tgb2vvmWFMbIc3LqN2ToNkZJvyYQ==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/import-local": {
       "version": "3.2.0",

--- a/src/ws/package.json
+++ b/src/ws/package.json
@@ -16,7 +16,7 @@
     "type": "git",
     "url": "git+https://github.com/bigskysoftware/htmx-extensions.git"
   },
-  "dependencies": {
+  "peerDependencies": {
     "htmx.org": "^2.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description
PR #123 made htmx a dependency of each extension instead of a dev dependency.
One reason given was to ensure a minimum version of htmx is installed that's compatible with the extension.
Unfortunately this doesn't work in practice, so rather than flagging any version mismatch, if there's a conflict NPM will instead create its own nested version of htmx for the extension and that will end up in the bundle as well.
Changing the dependency to a peer one solved the problem and extensions/plugins are the intended use case for peer dependencies.

With my own test specifying a v1 release for htmx with a v2 of the SSE extension,
both a v1 and v2 release of htmx ended up in the final bundle, increasing bundle size from 65K to 115K.


Htmx version: 1.9.2 / 2.0.6
Used extension(s) version(s): 2.2.3 of SSE, plus a WIP version of my own extension


## Testing
I tested with my own extension to verify the behavior of normal vs. peer dependencies.
I ran `npm install` and `npm run test` for each extension.


## Checklist

* [x] I have read the [contribution guidelines](https://github.com/bigskysoftware/htmx-extensions/blob/main/CONTRIBUTING.md)
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
