### PR TITLE
feat(sse): Add support for hx-select attribute

### DIFF
--- a/src/sse/sse.js
+++ b/src/sse/sse.js
@@ -85,20 +85,24 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
    * @param {HTMLElement} elt
    */
   function registerSSE(elt) {
-    // Add message handlers for every `sse-swap` attribute
-    if (api.getAttributeValue(elt, 'sse-swap')) {
+  var sseSwapAttr = api.getAttributeValue(elt, 'sse-swap');
+  if (sseSwapAttr === null && api.getAttributeValue(elt, 'sse-connect') !== null) {
+      sseSwapAttr = 'message';
+  }
+
+  // Add message handlers for every `sse-swap` attribute
+  if (sseSwapAttr) {
       // Find closest existing event source
       var sourceElement = api.getClosestMatch(elt, hasEventSource)
       if (sourceElement == null) {
-        // api.triggerErrorEvent(elt, "htmx:noSSESourceError")
-        return null // no eventsource in parentage, orphaned element
+      // api.triggerErrorEvent(elt, "htmx:noSSESourceError")
+      return null // no eventsource in parentage, orphaned element
       }
 
       // Set internalData and source
       var internalData = api.getInternalData(sourceElement)
       var source = internalData.sseEventSource
 
-      var sseSwapAttr = api.getAttributeValue(elt, 'sse-swap')
       var sseEventNames = sseSwapAttr.split(',')
 
       for (var i = 0; i < sseEventNames.length; i++) {

--- a/src/sse/sse.js
+++ b/src/sse/sse.js
@@ -280,7 +280,14 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 
     var swapSpec = api.getSwapSpecification(elt)
     var target = api.getTarget(elt)
-    api.swap(target, content, swapSpec, { contextElement: elt })
+    var select = api.getClosestAttributeValue(elt, 'hx-select')
+
+    var swapOptions = {
+        select: select,
+        contextElement: elt
+    };
+
+    api.swap(target, content, swapSpec, swapOptions)
   }
 
 

--- a/src/sse/test/ext/sse.js
+++ b/src/sse/test/ext/sse.js
@@ -702,4 +702,14 @@ describe('sse extension', function() {
     byId('d1').innerHTML.should.equal('div1 updated')
     byId('d2').innerHTML.should.equal('div2 updated')
   })
+
+  it('swaps content properly on SSE swap with hx-select', function() {
+    var div = make('<div hx-ext="sse" sse-connect="/event_stream">' +
+                   '  <div id="d1" sse-swap="e1" hx-select="#s1"></div>' +
+                   '</div>')
+    this.clock.tick(1)
+    byId('d1').innerText.should.equal('')
+    this.eventSource.sendEvent('e1', '<div><div id="s1">Event 1</div></div>')
+    byId('d1').innerText.should.equal('Event 1')
+  })
 })

--- a/src/sse/test/ext/sse.js
+++ b/src/sse/test/ext/sse.js
@@ -712,4 +712,12 @@ describe('sse extension', function() {
     this.eventSource.sendEvent('e1', '<div><div id="s1">Event 1</div></div>')
     byId('d1').innerText.should.equal('Event 1')
   })
+
+  it('defaults to message event if sse-swap is not specified', function() {
+    var div = make('<div id="d1" hx-ext="sse" sse-connect="/event_stream"></div>');
+    this.clock.tick(1);
+    byId('d1').innerText.should.equal('');
+    this.eventSource.sendEvent('message', 'Event 1');
+    byId('d1').innerText.should.equal('Event 1');
+  });
 })


### PR DESCRIPTION
Previously, the SSE extension did not respect `hx-select` for selecting elements from HTML in the event stream received.

This makes it possible to use `hx-select` to choose what will be picked & swapped from the event stream.

This should make the extension more powerful and consistent with the rest of htmx.

Htmx version: 2.0.6
Used extension(s) version(s): 2.2.2

## Checklist

* [x] I have read the [contribution guidelines](https://github.com/bigskysoftware/htmx-extensions/blob/main/CONTRIBUTING.md)
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
