### PR TITLE
SSE Extension: Add support for `hx-select`

### DIFF
--- a/src/sse/sse.js
+++ b/src/sse/sse.js
@@ -280,7 +280,14 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
 
     var swapSpec = api.getSwapSpecification(elt)
     var target = api.getTarget(elt)
-    api.swap(target, content, swapSpec, { contextElement: elt })
+    var select = api.getClosestAttributeValue(elt, 'hx-select')
+
+    var swapOptions = {
+        select: select,
+        contextElement: elt
+    };
+
+    api.swap(target, content, swapSpec, swapOptions)
   }
 
 

--- a/src/sse/test/ext/sse.js
+++ b/src/sse/test/ext/sse.js
@@ -702,4 +702,14 @@ describe('sse extension', function() {
     byId('d1').innerHTML.should.equal('div1 updated')
     byId('d2').innerHTML.should.equal('div2 updated')
   })
+
+  it('swaps content properly on SSE swap with hx-select', function() {
+    var div = make('<div hx-ext="sse" sse-connect="/event_stream">' +
+                   '  <div id="d1" sse-swap="e1" hx-select="#s1"></div>' +
+                   '</div>')
+    this.clock.tick(1)
+    byId('d1').innerText.should.equal('')
+    this.eventSource.sendEvent('e1', '<div><div id="s1">Event 1</div></div>')
+    byId('d1').innerText.should.equal('Event 1')
+  })
 })


### PR DESCRIPTION
You can now use `hx-select` to select a portion of HTML from an SSE event to swap, just like you can with `hx-get` or `hx-post`.

Example:

**Server Event:**
```
data: <div id="message">Hello</div><div id="status">Online</div>
```

You can now select and swap just the `#message` div:

**HTML:**
```html
<div sse-connect="/events" sse-swap="message" hx-select="#message">
<!-- This div will be updated with the content of #message -->
</div>
```

Htmx version: 2.0.6
Used extension(s) version(s): 2.2.2

## Checklist

* [x] I have read the [contribution guidelines](https://github.com/bigskysoftware/htmx-extensions/blob/main/CONTRIBUTING.md)
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
