### PR TITLE
SSE Extension: Default `sse-swap="message"` to keep setup simple

### DIFF
--- a/src/sse/sse.js
+++ b/src/sse/sse.js
@@ -85,20 +85,24 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
    * @param {HTMLElement} elt
    */
   function registerSSE(elt) {
-    // Add message handlers for every `sse-swap` attribute
-    if (api.getAttributeValue(elt, 'sse-swap')) {
+  var sseSwapAttr = api.getAttributeValue(elt, 'sse-swap');
+  if (sseSwapAttr === null && api.getAttributeValue(elt, 'sse-connect') !== null) {
+      sseSwapAttr = 'message';
+  }
+
+  // Add message handlers for every `sse-swap` attribute
+  if (sseSwapAttr) {
       // Find closest existing event source
       var sourceElement = api.getClosestMatch(elt, hasEventSource)
       if (sourceElement == null) {
-        // api.triggerErrorEvent(elt, "htmx:noSSESourceError")
-        return null // no eventsource in parentage, orphaned element
+      // api.triggerErrorEvent(elt, "htmx:noSSESourceError")
+      return null // no eventsource in parentage, orphaned element
       }
 
       // Set internalData and source
       var internalData = api.getInternalData(sourceElement)
       var source = internalData.sseEventSource
 
-      var sseSwapAttr = api.getAttributeValue(elt, 'sse-swap')
       var sseEventNames = sseSwapAttr.split(',')
 
       for (var i = 0; i < sseEventNames.length; i++) {

--- a/src/sse/sse.js
+++ b/src/sse/sse.js
@@ -86,7 +86,14 @@ This extension adds support for Server Sent Events to htmx.  See /www/extensions
    */
   function registerSSE(elt) {
   var sseSwapAttr = api.getAttributeValue(elt, 'sse-swap');
-  if (sseSwapAttr === null && api.getAttributeValue(elt, 'sse-connect') !== null) {
+  var sseConnectAttr = api.getAttributeValue(elt, 'sse-connect');
+
+  var hasSseSwap = sseSwapAttr !== null;
+  var hasSseConnect = sseConnectAttr !== null;
+  var hasNestedSseSwap = elt.querySelector('[sse-swap], [data-sse-swap]') !== null;
+
+  if (hasSseConnect && !(hasSseSwap || hasNestedSseSwap)) {
+      // Default `sse-swap` to `message`
       sseSwapAttr = 'message';
   }
 

--- a/src/sse/test/ext/sse.js
+++ b/src/sse/test/ext/sse.js
@@ -702,4 +702,12 @@ describe('sse extension', function() {
     byId('d1').innerHTML.should.equal('div1 updated')
     byId('d2').innerHTML.should.equal('div2 updated')
   })
+
+  it('defaults to message event if sse-swap is not specified', function() {
+    var div = make('<div id="d1" hx-ext="sse" sse-connect="/event_stream"></div>');
+    this.clock.tick(1);
+    byId('d1').innerText.should.equal('');
+    this.eventSource.sendEvent('message', 'Event 1');
+    byId('d1').innerText.should.equal('Event 1');
+  });
 })


### PR DESCRIPTION
## Summary

I wish this minimal setup just worked™:


```html
<div sse-connect="/events">Loading…</div>
```
```html
data: <span>I'm an unnamed event!</span>
```

**Expectation:** 
Payload from `data:` swaps directly into `<div sse-connect=...>` (using default swap strategy `innerHTML`).

**Reality:**
Unnamed events are ignored, unless you add `sse-swap="message"` to `sse-connect` element.


## Why?

I understand [browsers treat unnamed SSE events as `message` by default](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#listening_for_message_events), but with this change we could:
1. Match the extension's default with the browser's default
2. Match the extension's behaviour with the behavior of `hx-get`/`hx-post` (where `hx-target="this"` is implicit)
3. Remove the gotcha & keep simple scenarios simple.


## Implementation

Add `sse-swap="message"` by default on the `sse-connect` element (unless there's any nested `sse-swap` attributes).


## Edge Cases

### Nested swaps

The pattern of using nested `sse-swap` attributes should continue to work (default is not applied in this scenario).

```html
<div sse-connect="/events">
  <div sse-swap="foo"></div>
  <div sse-swap="bar"></div>
</div>
```


### Triggering Server Callbacks

The pattern of triggering server callbacks should continue to work normally because the default `message` listener only catches unnamed events.

```html
<div hx-ext="sse" sse-connect="/event_stream">
    <div hx-get="/chatroom" hx-trigger="sse:chatter">
        ...
    </div>
</div>
```

---

Htmx version: 2.0.6
Used extension(s) version(s): 2.2.2

## Checklist

* [x] I have read the [contribution guidelines](https://github.com/bigskysoftware/htmx-extensions/blob/main/CONTRIBUTING.md)
* [x] I ran the test suite locally (`npm run test`) and verified that it succeeded
